### PR TITLE
Implement interactive Meetups gallery for M6

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -399,6 +399,320 @@
   font-weight: 600;
 }
 
+/* Meetups gallery */
+.meetups-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  touch-action: pan-y pinch-zoom;
+}
+
+.meetups-gallery__viewport {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.75rem;
+  padding: 0.4rem;
+  background: rgba(12, 18, 52, 0.45);
+  border: 1px solid rgba(163, 174, 255, 0.25);
+}
+
+.meetups-gallery__viewport:focus-visible {
+  outline: 2px solid var(--meetup-active-accent, #ff66c4);
+  outline-offset: 4px;
+}
+
+.meetups-gallery__track {
+  display: flex;
+  transition: transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
+  will-change: transform;
+}
+
+.meetup-card {
+  flex: 0 0 100%;
+  position: relative;
+  overflow: hidden;
+  padding: 1.4rem;
+  border-radius: 1.5rem;
+  background: rgba(9, 11, 32, 0.7);
+  border: 1px solid rgba(163, 174, 255, 0.35);
+  box-shadow: 0 18px 48px -26px rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  color: #f5f4ff;
+}
+
+.meetup-card:focus-visible {
+  outline: none;
+  box-shadow: 0 18px 48px -18px rgba(0, 0, 0, 0.75),
+    0 0 0 2px rgba(255, 255, 255, 0.35);
+}
+
+.meetup-card__art {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.meetup-card__art::before {
+  content: '';
+  position: absolute;
+  inset: -28%;
+  background-image: var(--meetup-art-gradient);
+  filter: blur(0px);
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.meetup-card__art::after {
+  content: '';
+  position: absolute;
+  inset: -28%;
+  background-image: var(--meetup-art-overlay);
+  mix-blend-mode: screen;
+  opacity: var(--meetup-art-overlay-opacity, 0.35);
+}
+
+.meetup-card__grain {
+  position: absolute;
+  inset: -12%;
+  background-image:
+    radial-gradient(circle at 1px 1px, rgba(255, 255, 255, 0.28) 1px, transparent 1px),
+    radial-gradient(circle at 4px 3px, rgba(0, 0, 0, 0.4) 1px, transparent 1px);
+  background-size: 6px 6px, 7px 7px;
+  mix-blend-mode: soft-light;
+  opacity: var(--meetup-art-noise-opacity, 0.22);
+  animation: meetup-grain 12s steps(1, end) infinite;
+}
+
+@keyframes meetup-grain {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  20% {
+    transform: translate3d(-6px, -4px, 0);
+  }
+  40% {
+    transform: translate3d(4px, -2px, 0);
+  }
+  60% {
+    transform: translate3d(-2px, 5px, 0);
+  }
+  80% {
+    transform: translate3d(3px, 3px, 0);
+  }
+  100% {
+    transform: translate3d(0, 0, 0);
+  }
+}
+
+.meetup-card__content {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 1rem;
+}
+
+.meetup-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.meetup-card__month {
+  align-self: flex-start;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(6, 10, 32, 0.6);
+  font-size: 0.72rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--meetup-art-accent, #ff66c4);
+}
+
+.meetup-card__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 4vw, 1.6rem);
+  line-height: 1.3;
+}
+
+.meetup-card__location {
+  margin: 0;
+  color: rgba(245, 244, 255, 0.72);
+  font-size: 0.9rem;
+}
+
+.meetup-card__photo {
+  margin: 0;
+  position: relative;
+  width: 100%;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  border: 1px solid rgba(245, 244, 255, 0.22);
+  background: rgba(5, 8, 28, 0.45);
+  box-shadow: 0 14px 44px -28px rgba(0, 0, 0, 0.9);
+}
+
+.meetup-card__photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.meetup-card__caption {
+  position: absolute;
+  inset: auto 0 0 0;
+  padding: 0.65rem 0.85rem 0.8rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(
+    180deg,
+    rgba(4, 5, 16, 0) 0%,
+    rgba(4, 5, 16, 0.75) 100%
+  );
+}
+
+.meetup-card__summary {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.meetup-card__moments {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.meetup-card__moments li::marker {
+  color: var(--meetup-art-accent, rgba(255, 255, 255, 0.6));
+}
+
+.meetup-card__memo {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 1.1rem;
+  border-left: 2px solid var(--meetup-art-accent, #ff66c4);
+  background: rgba(8, 14, 42, 0.65);
+  color: rgba(245, 244, 255, 0.8);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+.meetups-gallery__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.6);
+}
+
+.meetups-gallery__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.meetups-gallery__control {
+  border: 1px solid rgba(163, 174, 255, 0.4);
+  border-radius: 999px;
+  background: rgba(6, 10, 32, 0.55);
+  color: #f5f4ff;
+  padding: 0.6rem 1.15rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.meetups-gallery__control:enabled:hover,
+.meetups-gallery__control:enabled:focus-visible {
+  color: var(--meetup-active-accent, #ff66c4);
+  border-color: var(--meetup-active-accent, #ff66c4);
+  background: rgba(10, 18, 48, 0.75);
+  outline: none;
+}
+
+.meetups-gallery__control:disabled {
+  opacity: 0.35;
+}
+
+.meetups-gallery__status {
+  flex: 1;
+  text-align: center;
+  font-size: 0.8rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+}
+
+.meetups-gallery__dots {
+  display: flex;
+  justify-content: center;
+  gap: 0.45rem;
+}
+
+.meetups-gallery__dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(245, 244, 255, 0.28);
+  padding: 0;
+  transition: transform 0.25s ease, background 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.meetups-gallery__dot:focus-visible {
+  outline: 2px solid var(--meetup-active-accent, #ff66c4);
+  outline-offset: 2px;
+}
+
+.meetups-gallery__dot--active {
+  background: var(--meetup-active-accent, #ff66c4);
+  transform: scale(1.25);
+  box-shadow: 0 0 0 6px rgba(255, 255, 255, 0.08);
+}
+
+@media (min-width: 720px) {
+  .meetup-card {
+    padding: 1.8rem;
+  }
+
+  .meetup-card__content {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .meetup-card__header {
+    grid-column: 1 / -1;
+  }
+
+  .meetup-card__photo {
+    grid-row: 2 / span 3;
+    grid-column: 1;
+    align-self: stretch;
+  }
+
+  .meetup-card__summary,
+  .meetup-card__moments,
+  .meetup-card__memo {
+    grid-column: 2;
+  }
+
+  .meetup-card__memo {
+    grid-column: 1 / -1;
+  }
+}
+
 /* removed fixed phone frame on large screens to allow full-bleed both orientations */
 
 /* Hide HUD on intro */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { DistanceHUD } from './components/DistanceHUD'
 import { GlobalStarfield } from './components/GlobalStarfield'
 import { BuildStamp } from './components/BuildStamp'
 import { journeys } from './data/journeys'
+import { meetups } from './data/meetups'
 import { useStoredJourneyResponses } from './hooks/useStoredJourneyResponses'
 import { IntroScene } from './scenes/IntroScene'
 import { JourneysScene } from './scenes/JourneysScene'
@@ -92,6 +93,7 @@ function App() {
     totalDistance,
     responses,
     saveResponse,
+    meetups,
   }
 
   return (

--- a/src/components/MeetupGallery.tsx
+++ b/src/components/MeetupGallery.tsx
@@ -1,0 +1,229 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import type { CSSProperties } from 'react'
+import type { MeetupEntry } from '../types/meetup'
+
+interface MeetupGalleryProps {
+  meetups: MeetupEntry[]
+}
+
+const clampIndex = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max)
+
+const SWIPE_THRESHOLD_PX = 40
+
+export const MeetupGallery = ({ meetups }: MeetupGalleryProps) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const viewportRef = useRef<HTMLDivElement | null>(null)
+  const pointerStartX = useRef<number | null>(null)
+  const [announcement, setAnnouncement] = useState('')
+
+  const totalMeetups = meetups.length
+  const activeMeetup = meetups[activeIndex]
+
+  useEffect(() => {
+    if (!activeMeetup) {
+      setAnnouncement('')
+      return
+    }
+    setAnnouncement(`${activeMeetup.monthLabel} — ${activeMeetup.title}`)
+  }, [activeMeetup])
+
+  const goTo = (index: number) => {
+    if (!totalMeetups) return
+    setActiveIndex((prev) => {
+      const clamped = clampIndex(index, 0, totalMeetups - 1)
+      if (clamped === prev) return prev
+      return clamped
+    })
+  }
+
+  const goNext = () => goTo(activeIndex + 1)
+  const goPrev = () => goTo(activeIndex - 1)
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      goNext()
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      goPrev()
+    }
+  }
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    pointerStartX.current = event.clientX
+    viewportRef.current?.setPointerCapture(event.pointerId)
+  }
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (pointerStartX.current === null) return
+
+    const delta = event.clientX - pointerStartX.current
+    if (delta > SWIPE_THRESHOLD_PX) {
+      goPrev()
+    } else if (delta < -SWIPE_THRESHOLD_PX) {
+      goNext()
+    }
+
+    pointerStartX.current = null
+    if (viewportRef.current?.hasPointerCapture(event.pointerId)) {
+      viewportRef.current.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const handlePointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    pointerStartX.current = null
+    if (viewportRef.current?.hasPointerCapture(event.pointerId)) {
+      viewportRef.current.releasePointerCapture(event.pointerId)
+    }
+  }
+
+  const accentColor = activeMeetup?.art.accent ?? '#ff66c4'
+
+  const galleryStyle = useMemo(
+    () => ({ '--meetup-active-accent': accentColor } as CSSProperties),
+    [accentColor]
+  )
+
+  const trackStyle = useMemo(
+    () => ({ transform: `translateX(-${activeIndex * 100}%)` }),
+    [activeIndex]
+  )
+
+  return (
+    <section
+      className="meetups-gallery"
+      style={galleryStyle}
+      aria-roledescription="carousel"
+      aria-label="月ごとの思い出アルバム"
+    >
+      <div
+        className="meetups-gallery__viewport"
+        ref={viewportRef}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onKeyDown={handleKeyDown}
+        role="group"
+        aria-live="polite"
+        tabIndex={0}
+      >
+        <div className="meetups-gallery__track" style={trackStyle}>
+          {meetups.map((meetup, index) => (
+            <MeetupCard
+              key={meetup.id}
+              meetup={meetup}
+              isActive={index === activeIndex}
+            />
+          ))}
+        </div>
+      </div>
+      <p className="meetups-gallery__hint">スワイプかボタンで月を切り替えできます。</p>
+      <div className="meetups-gallery__controls">
+        <button
+          type="button"
+          className="meetups-gallery__control"
+          onClick={goPrev}
+          disabled={activeIndex === 0}
+        >
+          前の月
+        </button>
+        <div className="meetups-gallery__status" aria-live="polite">
+          {announcement}
+        </div>
+        <button
+          type="button"
+          className="meetups-gallery__control"
+          onClick={goNext}
+          disabled={activeIndex === totalMeetups - 1}
+        >
+          次の月
+        </button>
+      </div>
+      <div className="meetups-gallery__dots" role="tablist" aria-label="月一覧">
+        {meetups.map((meetup, index) => (
+          <button
+            key={meetup.id}
+            type="button"
+            className={`meetups-gallery__dot${
+              index === activeIndex ? ' meetups-gallery__dot--active' : ''
+            }`}
+            onClick={() => goTo(index)}
+            aria-label={`${meetup.monthLabel} ${meetup.title}`}
+            aria-pressed={index === activeIndex}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+interface MeetupCardProps {
+  meetup: MeetupEntry
+  isActive: boolean
+}
+
+const MeetupCard = ({ meetup, isActive }: MeetupCardProps) => {
+  const {
+    art: { gradient, overlay, overlayOpacity, accent, noiseOpacity },
+  } = meetup
+
+  const cardStyle = useMemo(
+    () =>
+      ({
+        '--meetup-art-gradient': gradient,
+        '--meetup-art-overlay': overlay ?? 'none',
+        '--meetup-art-overlay-opacity': String(overlayOpacity ?? 0.35),
+        '--meetup-art-accent': accent,
+        '--meetup-art-noise-opacity': String(noiseOpacity ?? 0.22),
+      }) as CSSProperties,
+    [gradient, overlay, overlayOpacity, accent, noiseOpacity]
+  )
+
+  const photoAspect = meetup.photo.aspectRatio ?? 3 / 4
+
+  return (
+    <article
+      className="meetup-card"
+      style={cardStyle}
+      aria-hidden={!isActive}
+      tabIndex={isActive ? 0 : -1}
+    >
+      <div className="meetup-card__art" aria-hidden="true">
+        <div className="meetup-card__grain" />
+      </div>
+      <div className="meetup-card__content">
+        <header className="meetup-card__header">
+          <span className="meetup-card__month">{meetup.monthLabel}</span>
+          <h2 className="meetup-card__title">{meetup.title}</h2>
+          <p className="meetup-card__location">{meetup.location}</p>
+        </header>
+        <figure
+          className="meetup-card__photo"
+          style={{ aspectRatio: photoAspect } as CSSProperties}
+        >
+          <img src={meetup.photo.url} alt={meetup.photo.alt} />
+          {meetup.photo.caption ? (
+            <figcaption className="meetup-card__caption">
+              {meetup.photo.caption}
+            </figcaption>
+          ) : null}
+        </figure>
+        <p className="meetup-card__summary">{meetup.summary}</p>
+        <ul className="meetup-card__moments">
+          {meetup.highlights.map((highlight) => (
+            <li key={highlight}>{highlight}</li>
+          ))}
+        </ul>
+        {meetup.memo ? (
+          <p className="meetup-card__memo">{meetup.memo}</p>
+        ) : null}
+      </div>
+    </article>
+  )
+}

--- a/src/data/meetups.ts
+++ b/src/data/meetups.ts
@@ -1,0 +1,205 @@
+import type { MeetupEntry } from '../types/meetup'
+
+export const meetups: MeetupEntry[] = [
+  {
+    id: '2023-10-sky-fest',
+    monthLabel: '2023.10',
+    title: '空フェス夜市で合流',
+    location: '福岡・空フェス夜市',
+    summary:
+      '福岡出張の最終日、終電ギリギリで合流した夜市。提灯の明かりに包まれながら、「ここから1年が始まるんだ」とふたりで笑った。',
+    highlights: [
+      '流星群を模したレーザー演出と同時に並んだスカイランタン',
+      '屋台の炙り明太バターを半分こして頬がゆるむ',
+      '帰り道に撮った最初のツーショットが今も待ち受け',
+    ],
+    photo: {
+      url: 'https://images.unsplash.com/photo-1470225620780-dba8ba36b745?auto=format&fit=crop&w=1080&q=80',
+      alt: '夜市の提灯が連なる通り',
+      aspectRatio: 3 / 4,
+      caption: '空フェス夜市にて — 1年の旅の始まり',
+    },
+    art: {
+      gradient: `
+        radial-gradient(circle at 18% 22%, rgba(255, 160, 214, 0.6), transparent 58%),
+        radial-gradient(circle at 74% 18%, rgba(86, 207, 255, 0.42), transparent 52%),
+        radial-gradient(circle at 78% 78%, rgba(255, 209, 102, 0.3), transparent 60%),
+        linear-gradient(145deg, rgba(28, 16, 60, 0.95), rgba(6, 8, 32, 0.92))
+      `,
+      overlay:
+        'repeating-conic-gradient(from 45deg, rgba(255,255,255,0.08) 0deg 10deg, transparent 10deg 24deg)',
+      overlayOpacity: 0.42,
+      accent: '#ff9edb',
+      noiseOpacity: 0.18,
+    },
+    memo:
+      'イントロで描いた「夜空のプログラム起動」から繋がる、リアルな空フェスの思い出。',
+  },
+  {
+    id: '2023-12-illumination',
+    monthLabel: '2023.12',
+    title: '冬のイルミ散歩',
+    location: '東京・恵比寿ガーデンプレイス',
+    summary:
+      '真冬の青いイルミネーションとホットワイン。少し赤い鼻を笑い合いながら、今年の抱負をこっそり録音した夜。',
+    highlights: [
+      'ポラロイド写真を撮った瞬間、雪のように光が舞った',
+      '「プレゼントは手紙でお願い」と約束した原点',
+      '寒さに負けずにベンチで語った30分の未来メモ',
+    ],
+    photo: {
+      url: 'https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1080&q=80',
+      alt: '冬のイルミネーションが輝く並木道',
+      aspectRatio: 2 / 3,
+      caption: '青い光で染まった帰り道',
+    },
+    art: {
+      gradient: `
+        radial-gradient(circle at 20% 24%, rgba(137, 183, 255, 0.58), transparent 60%),
+        radial-gradient(circle at 80% 30%, rgba(255, 166, 240, 0.45), transparent 55%),
+        radial-gradient(circle at 68% 82%, rgba(152, 228, 255, 0.3), transparent 62%),
+        linear-gradient(160deg, rgba(18, 27, 68, 0.95), rgba(9, 10, 32, 0.92))
+      `,
+      overlay:
+        'repeating-linear-gradient(135deg, rgba(255,255,255,0.08) 0 12px, transparent 12px 36px)',
+      overlayOpacity: 0.35,
+      accent: '#9cd4ff',
+      noiseOpacity: 0.2,
+    },
+    memo: '鼻先が赤くなるほど寒いのに、写真からは熱量しか伝わってこないのが不思議。',
+  },
+  {
+    id: '2024-02-onsen',
+    monthLabel: '2024.02',
+    title: '朝霧の温泉トリップ',
+    location: '大分・由布院',
+    summary:
+      '湯けむりの向こうで夜明けを待つ露天風呂。指先がふやけるまで語った「次の旅先リスト」が、今もふたりのToDo。',
+    highlights: [
+      '貸切露天で聞いた音は、湯の音と遠くの鳥の声だけ',
+      '朝食のフルーツ牛乳で乾杯 — 旅の定番ルール化',
+      '帰りの特急で書いた交換日記1ページ目',
+    ],
+    photo: {
+      url: 'https://images.unsplash.com/photo-1512453979798-5ea266f8880c?auto=format&fit=crop&w=1200&q=80',
+      alt: '湯けむりが立ち上る温泉と山並み',
+      aspectRatio: 4 / 3,
+      caption: '朝霧に包まれた由布院の露天風呂',
+    },
+    art: {
+      gradient: `
+        radial-gradient(circle at 28% 28%, rgba(144, 255, 206, 0.42), transparent 58%),
+        radial-gradient(circle at 74% 22%, rgba(255, 179, 230, 0.42), transparent 55%),
+        radial-gradient(circle at 52% 78%, rgba(104, 210, 255, 0.35), transparent 60%),
+        linear-gradient(170deg, rgba(10, 30, 48, 0.95), rgba(8, 17, 38, 0.95))
+      `,
+      overlay:
+        'repeating-radial-gradient(circle at 50% 50%, rgba(255,255,255,0.08) 0 18px, transparent 18px 42px)',
+      overlayOpacity: 0.32,
+      accent: '#7ef5c4',
+      noiseOpacity: 0.16,
+    },
+    memo:
+      '湯上がりの火照った頬で撮ったセルフィーが、旅アルバムの中で一番リラックスした表情かもしれない。',
+  },
+  {
+    id: '2024-04-hanami',
+    monthLabel: '2024.04',
+    title: '花びらのトンネル',
+    location: '東京・目黒川沿い',
+    summary:
+      '散りぎわの桜吹雪。風が吹くたびに傘がピンクに染まって、写真も記憶もパステルフィルムのようになった春の午後。',
+    highlights: [
+      '満開を過ぎた枝から降る花びらシャワーで笑い声が止まらない',
+      'サンドイッチと桜餅を持ち寄ってベンチで即席ピクニック',
+      '川面に浮かぶ花びらを指差しながら作った小さな俳句ゲーム',
+    ],
+    photo: {
+      url: 'https://images.unsplash.com/photo-1490772888775-55fceea286b7?auto=format&fit=crop&w=1080&q=80',
+      alt: '桜が咲く川沿いの道を歩くふたり',
+      aspectRatio: 3 / 4,
+      caption: '目黒川の桜吹雪で足元までピンク色に',
+    },
+    art: {
+      gradient: `
+        radial-gradient(circle at 20% 26%, rgba(255, 186, 206, 0.58), transparent 60%),
+        radial-gradient(circle at 78% 18%, rgba(255, 235, 166, 0.45), transparent 55%),
+        radial-gradient(circle at 50% 78%, rgba(180, 220, 255, 0.32), transparent 65%),
+        linear-gradient(145deg, rgba(28, 12, 52, 0.92), rgba(48, 12, 45, 0.9))
+      `,
+      overlay:
+        'repeating-conic-gradient(from 90deg, rgba(255,255,255,0.08) 0deg 5deg, transparent 5deg 15deg)',
+      overlayOpacity: 0.38,
+      accent: '#ffb3c6',
+      noiseOpacity: 0.18,
+    },
+    memo: '花吹雪の動画をスローモーションで撮ったら、まるでMVのワンシーンみたいで何度も見返した。',
+  },
+  {
+    id: '2024-07-beach',
+    monthLabel: '2024.07',
+    title: '波待ちのサンセット',
+    location: '福岡・糸島サンセットビーチ',
+    summary:
+      '夕焼けの空と潮の匂い。サンセットに合わせて波の音が揃って、ふたりで裸足のまま砂に未来年表を描いた夏。',
+    highlights: [
+      '水平線に沈む瞬間、ハイタッチで夏の始まりを宣言',
+      '写ルンですで撮った逆光シルエットが最高の一枚に',
+      '夜は星空を見ながら、距離HUDの数字を数えて笑った',
+    ],
+    photo: {
+      url: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1200&q=80',
+      alt: '夕焼けのビーチで寄り添うふたりの影',
+      aspectRatio: 16 / 9,
+      caption: '潮風と夕焼けのグラデーション',
+    },
+    art: {
+      gradient: `
+        radial-gradient(circle at 18% 32%, rgba(255, 177, 105, 0.52), transparent 60%),
+        radial-gradient(circle at 82% 22%, rgba(255, 114, 215, 0.45), transparent 55%),
+        radial-gradient(circle at 70% 80%, rgba(96, 210, 255, 0.35), transparent 60%),
+        linear-gradient(160deg, rgba(15, 24, 64, 0.95), rgba(10, 9, 32, 0.92))
+      `,
+      overlay:
+        'repeating-linear-gradient(110deg, rgba(255,255,255,0.06) 0 8px, transparent 8px 28px)',
+      overlayOpacity: 0.32,
+      accent: '#ffc17a',
+      noiseOpacity: 0.2,
+    },
+    memo: '足跡をたどって撮ったドローン風ショットを、Resultの背景に仕込みたい。',
+  },
+  {
+    id: '2024-09-anniversary',
+    monthLabel: '2024.09',
+    title: '1周年の前夜祭',
+    location: '東京・マンションのルーフトップ',
+    summary:
+      '都会の夜景を背景にしたささやかな前夜祭。手作りのライトと音楽でデッキを飾って、1年分の距離と好きの数を一緒に振り返った。',
+    highlights: [
+      '手すりに吊るしたフェアリーライトが星座みたいに瞬く',
+      'タブレットで流したプレイリストに合わせて即席ダンス',
+      'Apexリザルト案をホワイトボードに描きながら決めた夜',
+    ],
+    photo: {
+      url: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1080&q=80',
+      alt: '都会の夜景を見下ろすルーフトップの灯り',
+      aspectRatio: 3 / 4,
+      caption: 'ルーフトップ前夜祭のセッティング',
+    },
+    art: {
+      gradient: `
+        radial-gradient(circle at 24% 24%, rgba(255, 166, 255, 0.55), transparent 58%),
+        radial-gradient(circle at 78% 28%, rgba(118, 215, 255, 0.45), transparent 55%),
+        radial-gradient(circle at 56% 78%, rgba(255, 220, 141, 0.3), transparent 60%),
+        linear-gradient(165deg, rgba(18, 18, 54, 0.95), rgba(9, 6, 32, 0.92))
+      `,
+      overlay:
+        'repeating-conic-gradient(from 30deg, rgba(255,255,255,0.1) 0deg 4deg, transparent 4deg 14deg)',
+      overlayOpacity: 0.42,
+      accent: '#d0a7ff',
+      noiseOpacity: 0.22,
+    },
+    memo:
+      'ここで撮った夜景の写真をResultの背景に重ねて、Introのターミナル演出とループさせる予定。',
+  },
+]

--- a/src/scenes/MeetupsScene.tsx
+++ b/src/scenes/MeetupsScene.tsx
@@ -1,20 +1,21 @@
+import { MeetupGallery } from '../components/MeetupGallery'
 import { SceneLayout } from '../components/SceneLayout'
 import type { SceneComponentProps } from '../types/scenes'
 
-export const MeetupsScene = ({ onAdvance }: SceneComponentProps) => {
+export const MeetupsScene = ({ onAdvance, meetups }: SceneComponentProps) => {
   return (
     <SceneLayout
       eyebrow="Meetups"
       title="月ごとのアルバム"
-      description="月替わりのメディアアート背景に写真と手書きメモを載せる、展示会のようなギャラリーセクション。"
+      description="月替わりのメディアアート背景に、縦横の写真とハイライトメモを重ねる展示会スタイルのギャラリー。"
       onAdvance={onAdvance}
       advanceLabel="Letterへ"
     >
-      <ul className="scene-list">
-        <li>縦横比の異なるiPhone写真に対応するレイアウトを検討中。</li>
-        <li>スワイプ風のトランジションで月を切り替え、没入感を演出。</li>
-        <li>ここでも自由回答を差し込める余白を用意します。</li>
-      </ul>
+      <MeetupGallery meetups={meetups} />
+      <p className="scene-note">
+        最終版では各月の自由回答をこのカードに差し込む予定。グラデーション背景はデータから生成できるように設計し、
+        モバイルでもスワイプ操作で切り替えられるよう整えました。
+      </p>
     </SceneLayout>
   )
 }

--- a/src/types/meetup.ts
+++ b/src/types/meetup.ts
@@ -1,0 +1,32 @@
+export interface MeetupArt {
+  /** CSS gradient string that paints the main aurora-like background. */
+  gradient: string
+  /** Optional overlay pattern that sits on top of the gradient. */
+  overlay?: string
+  /** Optional opacity for the overlay pattern (0-1). Defaults to 0.35. */
+  overlayOpacity?: number
+  /** Accent color used for chips/borders that match the artwork. */
+  accent: string
+  /** Optional opacity for the grain layer (0-1). Defaults to 0.22. */
+  noiseOpacity?: number
+}
+
+export interface MeetupPhoto {
+  url: string
+  alt: string
+  /** Aspect ratio expressed as width / height. */
+  aspectRatio?: number
+  caption?: string
+}
+
+export interface MeetupEntry {
+  id: string
+  monthLabel: string
+  title: string
+  location: string
+  summary: string
+  highlights: string[]
+  photo: MeetupPhoto
+  art: MeetupArt
+  memo?: string
+}

--- a/src/types/scenes.ts
+++ b/src/types/scenes.ts
@@ -3,6 +3,7 @@ import type {
   JourneyPromptResponse,
   SaveJourneyResponsePayload,
 } from './experience'
+import type { MeetupEntry } from './meetup'
 
 export type SceneId =
   | 'intro'
@@ -22,6 +23,7 @@ export interface SceneComponentProps {
   totalDistance: number
   responses: JourneyPromptResponse[]
   saveResponse: (payload: SaveJourneyResponsePayload) => void
+  meetups: MeetupEntry[]
 }
 
 export const sceneOrder: SceneId[] = [


### PR DESCRIPTION
## Summary
- add typed dataset describing monthly meetups with generative art metadata
- introduce an interactive Meetups gallery component with swipe-like navigation and integrate it into the scene
- wire the new data through the scene props and style layer so the carousel matches the anniversary art direction

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4bd24ea8832fb34eea12e3e00232