### PR TITLE
Rework prologue dialogue around speaker backgrounds

### DIFF
--- a/public/images/gimmie-placeholder.svg
+++ b/public/images/gimmie-placeholder.svg
@@ -1,0 +1,23 @@
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="gp-bg" x1="12%" y1="12%" x2="88%" y2="88%">
+      <stop offset="0%" stop-color="#8f9bff" />
+      <stop offset="50%" stop-color="#7c4dff" />
+      <stop offset="100%" stop-color="#ff7ad6" />
+    </linearGradient>
+    <linearGradient id="gp-shine" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+    <linearGradient id="gp-inner" x1="20%" y1="15%" x2="85%" y2="85%">
+      <stop offset="0%" stop-color="#100935" />
+      <stop offset="100%" stop-color="#321256" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="120" height="120" rx="36" fill="url(#gp-inner)" stroke="url(#gp-bg)" stroke-width="8" />
+  <circle cx="48" cy="64" r="22" fill="none" stroke="#f1e7ff" stroke-width="10" stroke-linecap="round" />
+  <path d="M80 42c12.5 0 22 9.5 22 22s-9.5 22-22 22c-7.2 0-12.6-3.1-17.4-8.3" fill="none" stroke="#f1e7ff" stroke-width="10" stroke-linecap="round" />
+  <path d="M62 89c6.2 6.4 13.8 11 24 11 15.5 0 28-12.5 28-28s-12.5-28-28-28" fill="none" stroke="url(#gp-bg)" stroke-width="6" stroke-linecap="round" />
+  <path d="M35 35l18-18" stroke="url(#gp-shine)" stroke-width="6" stroke-linecap="round" />
+  <path d="M20 54l8-8" stroke="url(#gp-shine)" stroke-width="6" stroke-linecap="round" />
+</svg>

--- a/public/images/prologue-partner-placeholder.svg
+++ b/public/images/prologue-partner-placeholder.svg
@@ -1,0 +1,58 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="pp-dusk" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1a0d3c" />
+      <stop offset="50%" stop-color="#3c1a60" />
+      <stop offset="100%" stop-color="#421245" />
+    </linearGradient>
+    <linearGradient id="pp-window" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb3d5" stop-opacity="0.95" />
+      <stop offset="60%" stop-color="#ff739b" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#e33f76" stop-opacity="0.95" />
+    </linearGradient>
+    <linearGradient id="pp-table" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#331840" />
+      <stop offset="50%" stop-color="#441f52" />
+      <stop offset="100%" stop-color="#32143d" />
+    </linearGradient>
+    <radialGradient id="pp-glow" cx="50%" cy="10%" r="70%">
+      <stop offset="0%" stop-color="#fff7e6" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#fff7e6" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#pp-dusk)" />
+  <circle cx="360" cy="150" r="42" fill="#ffe7b9" opacity="0.7" />
+  <g opacity="0.88">
+    <rect x="980" y="120" width="520" height="360" rx="34" fill="#2d0e3b" opacity="0.5" />
+    <rect x="1000" y="140" width="480" height="320" rx="28" fill="url(#pp-window)" />
+    <g fill="#ffffff" opacity="0.2">
+      <circle cx="1120" cy="240" r="9" />
+      <circle cx="1260" cy="220" r="6" />
+      <circle cx="1400" cy="260" r="7" />
+      <circle cx="1320" cy="300" r="8" />
+      <circle cx="1180" cy="320" r="6" />
+    </g>
+  </g>
+  <path d="M240 520h1030v160c0 34-26 60-60 60H300c-34 0-60-26-60-60V520z" fill="url(#pp-table)" opacity="0.9" />
+  <rect x="360" y="470" width="240" height="90" rx="22" fill="#462058" opacity="0.82" />
+  <rect x="640" y="460" width="160" height="96" rx="24" fill="#54286a" opacity="0.86" />
+  <g transform="translate(280 420)" opacity="0.9">
+    <path d="M60 0h120v140c0 26-20 44-44 44H44c-26 0-44-18-44-44V44C0 18 18 0 44 0z" fill="#2b113a" />
+    <path d="M52 32h72v64H52z" fill="#3c1d51" />
+    <path d="M40 130h96v18H40z" fill="#40205a" />
+  </g>
+  <g transform="translate(880 450)" opacity="0.9">
+    <path d="M0 90c0-50 42-90 96-90h180c54 0 96 40 96 90v90c0 32-24 56-56 56H56c-32 0-56-24-56-56V90z" fill="#2f1340" />
+    <path d="M96 28h180c40 0 72 28 72 62v40c0 24-18 42-42 42H66c-24 0-42-18-42-42V90c0-34 32-62 72-62z" fill="#3d1e53" />
+    <rect x="142" y="102" width="88" height="22" rx="10" fill="#ff89b8" opacity="0.6" />
+  </g>
+  <circle cx="560" cy="520" r="110" fill="#ff86b9" opacity="0.18" />
+  <circle cx="520" cy="500" r="60" fill="#ffd1e6" opacity="0.32" />
+  <path d="M420 512c0-42 34-76 76-76 32 0 60 20 70 48" stroke="#ffc7e7" stroke-width="12" stroke-linecap="round" opacity="0.35" />
+  <ellipse cx="540" cy="640" rx="110" ry="18" fill="#0d0820" opacity="0.3" />
+  <ellipse cx="1100" cy="650" rx="140" ry="20" fill="#0d0820" opacity="0.28" />
+  <rect x="200" y="540" width="340" height="48" rx="20" fill="#ff94c6" opacity="0.38" />
+  <path d="M0 780h1600v120H0z" fill="#13071f" opacity="0.72" />
+  <path d="M0 720h1600v80H0z" fill="#1c0a2b" opacity="0.68" />
+  <ellipse cx="420" cy="160" rx="150" ry="50" fill="url(#pp-glow)" opacity="0.2" />
+</svg>

--- a/public/images/prologue-self-placeholder.svg
+++ b/public/images/prologue-self-placeholder.svg
@@ -1,0 +1,67 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="ps-night" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f1848" />
+      <stop offset="45%" stop-color="#1b2e73" />
+      <stop offset="100%" stop-color="#1a1042" />
+    </linearGradient>
+    <linearGradient id="ps-window" x1="10%" y1="0%" x2="90%" y2="100%">
+      <stop offset="0%" stop-color="#6aa8ff" stop-opacity="0.92" />
+      <stop offset="55%" stop-color="#2b53c7" stop-opacity="0.88" />
+      <stop offset="100%" stop-color="#1a2d7a" stop-opacity="0.95" />
+    </linearGradient>
+    <linearGradient id="ps-desk" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1b123d" />
+      <stop offset="50%" stop-color="#281b58" />
+      <stop offset="100%" stop-color="#1b123d" />
+    </linearGradient>
+    <linearGradient id="ps-lamp" x1="50%" y1="0%" x2="50%" y2="100%">
+      <stop offset="0%" stop-color="#ffd5f6" />
+      <stop offset="100%" stop-color="#ff8ad5" stop-opacity="0" />
+    </linearGradient>
+    <radialGradient id="ps-glow" cx="50%" cy="15%" r="70%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#ps-night)" />
+  <circle cx="1280" cy="120" r="48" fill="#ffe8ad" opacity="0.7" />
+  <g opacity="0.85">
+    <rect x="220" y="120" width="640" height="380" rx="32" fill="#0b112e" opacity="0.45" />
+    <rect x="240" y="140" width="600" height="340" rx="26" fill="url(#ps-window)" />
+    <g fill="#ffffff" opacity="0.16">
+      <circle cx="360" cy="220" r="8" />
+      <circle cx="500" cy="260" r="6" />
+      <circle cx="680" cy="200" r="5" />
+      <circle cx="430" cy="320" r="7" />
+      <circle cx="610" cy="310" r="9" />
+      <circle cx="700" cy="260" r="6" />
+    </g>
+  </g>
+  <path d="M160 520h960v140c0 32-26 58-58 58H218c-32 0-58-26-58-58V520z" fill="url(#ps-desk)" opacity="0.92" />
+  <rect x="220" y="470" width="320" height="90" rx="20" fill="#1f2658" opacity="0.85" />
+  <rect x="580" y="470" width="180" height="90" rx="20" fill="#1f2658" opacity="0.85" />
+  <rect x="1120" y="430" width="120" height="230" rx="28" fill="#1f1748" opacity="0.82" />
+  <path d="M1180 420c0-46 36-82 82-82h40" stroke="#f4c1ff" stroke-width="18" stroke-linecap="round" opacity="0.45" />
+  <circle cx="1240" cy="338" r="8" fill="#fdf4ff" opacity="0.7" />
+  <path d="M1180 430h88v24h-88z" fill="#272065" opacity="0.9" />
+  <path d="M360 520c0-64 48-110 124-110 60 0 102 28 126 72" stroke="#9db4ff" stroke-width="16" stroke-linecap="round" stroke-opacity="0.35" />
+  <g transform="translate(1020 460)">
+    <path d="M80 0h64v160c0 26-18 44-44 44H44c-26 0-44-18-44-44V44C0 18 18 0 44 0z" fill="#241748" opacity="0.72" />
+    <path d="M60 36h56v56H60z" fill="#32255f" opacity="0.92" />
+    <path d="M48 140h80v16H48z" fill="#352968" opacity="0.9" />
+  </g>
+  <ellipse cx="520" cy="612" rx="90" ry="14" fill="#0c0d24" opacity="0.3" />
+  <ellipse cx="1220" cy="622" rx="70" ry="12" fill="#0c0d24" opacity="0.25" />
+  <path d="M220 520h600" stroke="#3e4ca0" stroke-width="4" stroke-linecap="round" opacity="0.4" />
+  <ellipse cx="460" cy="520" rx="160" ry="32" fill="url(#ps-lamp)" opacity="0.6" />
+  <circle cx="420" cy="496" r="22" fill="#ffd9f4" opacity="0.8" />
+  <circle cx="420" cy="496" r="12" fill="#fff0ff" opacity="0.6" />
+  <path d="M540 440h120" stroke="#7f8cff" stroke-width="10" stroke-linecap="round" opacity="0.35" />
+  <path d="M540 460h140" stroke="#7f8cff" stroke-width="6" stroke-linecap="round" opacity="0.3" />
+  <path d="M540 480h180" stroke="#7f8cff" stroke-width="6" stroke-linecap="round" opacity="0.25" />
+  <rect x="920" y="540" width="220" height="46" rx="20" fill="#ff8ad5" opacity="0.45" />
+  <path d="M0 780h1600v120H0z" fill="#0c0d24" opacity="0.7" />
+  <path d="M0 720h1600v80H0z" fill="#120c32" opacity="0.7" />
+  <ellipse cx="1400" cy="176" rx="140" ry="48" fill="url(#ps-glow)" opacity="0.22" />
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -453,3 +453,285 @@
 /* Reserve space for ground on the Intro start scene so stars don't overlap ground */
 .scene-intro .global-starfield { bottom: 10ch; }
 .ascii-bottom-mask { position: absolute; left:0; right:0; bottom:0; height: 10ch; background: linear-gradient(180deg, rgba(10,12,42,0), #090320 60%, #090320 100%); }
+
+/* Prologue novel scene */
+.prologue {
+  position: relative;
+  flex: 1;
+  display: flex;
+  border-radius: 1.75rem;
+  padding: 1.75rem 1.5rem 1.5rem;
+  background: rgba(10, 14, 44, 0.6);
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(130, 150, 255, 0.35);
+  box-shadow: 0 28px 60px rgba(8, 6, 32, 0.55);
+  cursor: pointer;
+  color: inherit;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.prologue:focus-visible {
+  outline: 2px solid rgba(255, 153, 255, 0.7);
+  outline-offset: 4px;
+}
+
+.prologue__backdrops {
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  overflow: hidden;
+  border-radius: inherit;
+}
+
+.prologue__backdrop {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  transform: scale(1.025);
+  opacity: 0;
+  transition: opacity 420ms ease, transform 420ms ease;
+}
+
+.prologue__backdrop.is-active {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.prologue__backdrop--self {
+  background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
+    url('/images/prologue-self-placeholder.svg');
+}
+
+.prologue__backdrop--partner {
+  background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
+    url('/images/prologue-partner-placeholder.svg');
+}
+
+.prologue__backdrop-overlay {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 188, 255, 0.18), transparent 45%),
+    radial-gradient(circle at 82% 85%, rgba(82, 140, 255, 0.22), transparent 55%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  opacity: 0.8;
+}
+
+.prologue__content {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.prologue__call-ui {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.prologue__call-id {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.prologue__call-avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 1.25rem;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: linear-gradient(160deg, rgba(29, 36, 96, 0.65), rgba(90, 120, 210, 0.45));
+  border: 1px solid rgba(170, 190, 255, 0.35);
+  box-shadow: 0 12px 24px rgba(12, 8, 40, 0.35);
+}
+
+.prologue__call-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.prologue__call-label {
+  margin: 0;
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.65);
+}
+
+.prologue__call-status {
+  margin: 0.2rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.prologue__call-meter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.prologue__call-meter span {
+  width: 6px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(245, 244, 255, 0.28);
+  transition: background 0.35s ease;
+}
+
+.prologue__call-meter span.is-active {
+  background: linear-gradient(180deg, rgba(255, 102, 196, 0.7), rgba(87, 132, 255, 0.9));
+}
+
+.prologue__dialogue {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 0.5rem 0;
+}
+
+.prologue-line {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1rem 1.15rem;
+  border-radius: 1.2rem 1.2rem 1.2rem 0.6rem;
+  max-width: min(78vw, 500px);
+  background: rgba(18, 23, 58, 0.68);
+  border: 1px solid rgba(118, 146, 255, 0.38);
+  box-shadow: 0 18px 36px rgba(5, 6, 24, 0.4);
+  backdrop-filter: blur(12px);
+  animation: prologue-line-in 320ms ease forwards;
+  opacity: 0;
+  transform: translateY(12px);
+}
+
+.prologue-line--self {
+  align-self: flex-end;
+  border-radius: 1.2rem 1.2rem 0.5rem 1.2rem;
+  background: linear-gradient(160deg, rgba(255, 126, 213, 0.82), rgba(93, 139, 255, 0.88));
+  border: 1px solid rgba(255, 176, 225, 0.5);
+  color: #090320;
+  box-shadow: 0 22px 38px rgba(255, 126, 213, 0.3);
+}
+
+.prologue-line--partner {
+  align-self: flex-start;
+  border-radius: 1.2rem 1.2rem 1.2rem 0.5rem;
+  background: rgba(18, 23, 58, 0.72);
+  border: 1px solid rgba(148, 176, 255, 0.45);
+}
+
+.prologue-line--narration,
+.prologue-line--system {
+  align-self: center;
+  border-radius: 1.2rem;
+  background: rgba(12, 18, 52, 0.6);
+  border: 1px solid rgba(170, 190, 255, 0.25);
+  text-align: center;
+  box-shadow: none;
+}
+
+.prologue-line--system {
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(235, 238, 255, 0.75);
+}
+
+.prologue-line__speaker {
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.65);
+}
+
+.prologue-line--self .prologue-line__speaker {
+  color: rgba(9, 3, 32, 0.72);
+}
+
+.prologue-line__text {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.prologue__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding-top: 0.25rem;
+}
+
+.prologue__progress {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.prologue__progress span {
+  display: block;
+  width: 12px;
+  height: 3px;
+  border-radius: 999px;
+  background: rgba(245, 244, 255, 0.25);
+  transition: background 0.3s ease;
+}
+
+.prologue__progress span.is-active {
+  background: linear-gradient(90deg, rgba(255, 102, 196, 0.85), rgba(97, 140, 255, 0.95));
+}
+
+.prologue__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.75);
+}
+
+@keyframes prologue-line-in {
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .prologue {
+    transition: none;
+  }
+
+  .prologue-line {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .prologue__backdrop {
+    transition: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .prologue {
+    padding: 1.5rem 1.25rem 1.25rem;
+    border-radius: 1.5rem;
+  }
+
+  .prologue__call-avatar {
+    width: 40px;
+    height: 40px;
+  }
+}

--- a/src/data/prologue.ts
+++ b/src/data/prologue.ts
@@ -1,0 +1,88 @@
+export type PrologueLineVariant =
+  | 'system'
+  | 'narration'
+  | 'self'
+  | 'partner'
+
+export interface PrologueLine {
+  id: string
+  variant: PrologueLineVariant
+  speaker?: string
+  text: string
+}
+
+export const prologueScript: PrologueLine[] = [
+  {
+    id: 'call-start',
+    variant: 'system',
+    text: '21:04 — 通話接続中…',
+  },
+  {
+    id: 'partner-greeting',
+    variant: 'partner',
+    speaker: '彩音',
+    text: 'もしもし？今大丈夫？夜風が気持ちよくて、つい掛けちゃった。',
+  },
+  {
+    id: 'self-reply',
+    variant: 'self',
+    speaker: 'わたし',
+    text: 'もちろん。今ちょうど帰り道。空が今日やばいくらい綺麗だよ。',
+  },
+  {
+    id: 'partner-meteor',
+    variant: 'partner',
+    speaker: '彩音',
+    text: 'ほんとだ、窓の外に流れ星。ねえ、今日って空フェスの日じゃなかった？',
+  },
+  {
+    id: 'self-memory',
+    variant: 'self',
+    speaker: 'わたし',
+    text: 'そうそう。去年あそこで屋台巡りしたよね。あの夜から、もう一年か…。',
+  },
+  {
+    id: 'narration-spark',
+    variant: 'narration',
+    text: 'イヤホン越しのノイズが星屑みたいに弾け、画面に微かな光が走る。',
+  },
+  {
+    id: 'system-sync',
+    variant: 'system',
+    text: '通知: タイムスタンプ同期リクエストを検出。',
+  },
+  {
+    id: 'self-notice',
+    variant: 'self',
+    speaker: 'わたし',
+    text: 'え、今ピコンって鳴った？日付の通知なんて設定してないのに…。',
+  },
+  {
+    id: 'partner-alert',
+    variant: 'partner',
+    speaker: '彩音',
+    text: 'こっちも出たよ。「タイムラインを巻き戻します」って。どういうこと？',
+  },
+  {
+    id: 'narration-rollback',
+    variant: 'narration',
+    text: 'ロック画面の数字がゆっくり反転する。2025/10/07 → 2024/10/07。',
+  },
+  {
+    id: 'self-realize',
+    variant: 'self',
+    speaker: 'わたし',
+    text: '……待って。日付、ちょうど一年前に戻ってる。',
+  },
+  {
+    id: 'partner-surprise',
+    variant: 'partner',
+    speaker: '彩音',
+    text: 'うそ。記念日の前夜と同じ？そんなの、もう一回やるしかないじゃん。',
+  },
+  {
+    id: 'narration-transition',
+    variant: 'narration',
+    text: '鼓動が高鳴る。これから一年分の旅を、もう一度追体験する。',
+  },
+]

--- a/src/scenes/PrologueScene.tsx
+++ b/src/scenes/PrologueScene.tsx
@@ -1,20 +1,126 @@
-import { SceneLayout } from '../components/SceneLayout'
+import { useCallback, useEffect, useState } from 'react'
+
+import { prologueScript } from '../data/prologue'
 import type { SceneComponentProps } from '../types/scenes'
 
+const CALL_LABELS = ['RTC接続中']
+const CALL_AVATAR_SRC = '/images/gimmie-placeholder.svg'
+
 export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const totalLines = prologueScript.length
+  const isComplete = activeIndex >= totalLines - 1
+  const activeLabel = CALL_LABELS[Math.min(activeIndex, CALL_LABELS.length - 1)]
+  const currentLine = prologueScript[activeIndex]
+  const [activeBackdrop, setActiveBackdrop] = useState<'self' | 'partner'>(() => {
+    const firstSpeaker = prologueScript.find((line) =>
+      line.variant === 'self' || line.variant === 'partner'
+    )?.variant
+
+    return firstSpeaker === 'partner' ? 'partner' : 'self'
+  })
+
+  useEffect(() => {
+    if (currentLine?.variant === 'self' || currentLine?.variant === 'partner') {
+      setActiveBackdrop(currentLine.variant)
+    }
+  }, [currentLine?.variant])
+
+  const handleAdvance = useCallback(() => {
+    setActiveIndex((current) => {
+      if (current >= totalLines - 1) {
+        onAdvance()
+        return current
+      }
+
+      return current + 1
+    })
+  }, [onAdvance, totalLines])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault()
+        handleAdvance()
+      }
+    },
+    [handleAdvance]
+  )
+
   return (
-    <SceneLayout
-      eyebrow="Prologue"
-      title="ノベル導入（通話編）"
-      description="ゲーム内通話から不思議な出来事が始まり、『日付はちょうど一年前』という伏線をここで張ります。"
-      onAdvance={onAdvance}
-      advanceLabel="通話を続ける"
+    <section
+      className="prologue"
+      role="button"
+      tabIndex={0}
+      onClick={handleAdvance}
+      onKeyDown={handleKeyDown}
+      aria-label={isComplete ? 'Journeysへ進む' : 'タップでセリフを進める'}
     >
-      <ul className="scene-list">
-        <li>ノベルゲーム風のUIでセリフが1行ずつフェードイン。</li>
-        <li>タップで進行。背景は淡い夜空と通話UIの組み合わせ。</li>
-        <li>最後に『時間が巻き戻っている』ことに気付くセリフでJourneysへ遷移。</li>
-      </ul>
-    </SceneLayout>
+      <div className="prologue__backdrops" aria-hidden="true">
+        <div
+          className={`prologue__backdrop prologue__backdrop--self ${
+            activeBackdrop === 'self' ? 'is-active' : ''
+          }`}
+        />
+        <div
+          className={`prologue__backdrop prologue__backdrop--partner ${
+            activeBackdrop === 'partner' ? 'is-active' : ''
+          }`}
+        />
+        <div className="prologue__backdrop-overlay" />
+      </div>
+      <div className="prologue__content">
+        <header className="prologue__call-ui" aria-live="polite">
+          <div className="prologue__call-id">
+            <div className="prologue__call-avatar">
+              <img
+                src={CALL_AVATAR_SRC}
+                alt="Gimmie x Gimmieのサーバーアイコン"
+                loading="lazy"
+              />
+            </div>
+            <div>
+              <p className="prologue__call-label">彩音 — Gimmie x Gimmie</p>
+              <p className="prologue__call-status">{activeLabel}</p>
+            </div>
+          </div>
+          <div className="prologue__call-meter" aria-hidden="true">
+            {([0.33, 0.66, 0.92] as const).map((threshold) => (
+              <span
+                key={threshold}
+                className={
+                  activeIndex / Math.max(totalLines - 1, 1) >= threshold ? 'is-active' : ''
+                }
+              />
+            ))}
+          </div>
+        </header>
+
+        <div className="prologue__dialogue" role="presentation">
+          {currentLine ? (
+            <div key={currentLine.id} className={`prologue-line prologue-line--${currentLine.variant}`}>
+              {currentLine.speaker ? (
+                <span className="prologue-line__speaker">{currentLine.speaker}</span>
+              ) : null}
+              <p className="prologue-line__text">{currentLine.text}</p>
+            </div>
+          ) : null}
+        </div>
+
+        <footer className="prologue__footer" aria-hidden="true">
+          <div className="prologue__progress">
+            {prologueScript.map((line, index) => (
+              <span
+                key={line.id}
+                className={index <= activeIndex ? 'is-active' : undefined}
+              />
+            ))}
+          </div>
+          <p className="prologue__hint">
+            {isComplete ? 'タップでJourneysへ' : 'タップで続ける'}
+          </p>
+        </footer>
+      </div>
+    </section>
   )
 }


### PR DESCRIPTION
## Summary
- show one prologue line at a time, track the active speaker, and flip call backgrounds while updating the RTC status label
- refresh the prologue layout with dynamic backdrop layers, revised dialogue bubble styling, and a replaceable server icon slot
- rename the partner to 彩音 and add placeholder background and icon assets for future swaps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce4b2fef14832f8d8aa7bca028350b