### PR TITLE
Implement interactive Journeys experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -372,6 +372,15 @@
   font-size: 0.95rem;
 }
 
+.distance-hud__goal {
+  display: inline-block;
+  margin-left: 0.4rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+}
+
 .result-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -453,3 +462,487 @@
 /* Reserve space for ground on the Intro start scene so stars don't overlap ground */
 .scene-intro .global-starfield { bottom: 10ch; }
 .ascii-bottom-mask { position: absolute; left:0; right:0; bottom:0; height: 10ch; background: linear-gradient(180deg, rgba(10,12,42,0), #090320 60%, #090320 100%); }
+
+/* Journeys scene */
+.journeys-experience {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.journeys-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.journeys-header__row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.75);
+  font-size: 0.82rem;
+}
+
+.journeys-header__label {
+  font-weight: 600;
+  letter-spacing: 0.22em;
+}
+
+.journeys-header__distance {
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.16em;
+  color: #f5f4ff;
+}
+
+.journeys-progress-bar {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(163, 174, 255, 0.22);
+}
+
+.journeys-progress-bar__fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 102, 196, 0.9), rgba(77, 123, 255, 0.9));
+  transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.journeys-header__secondary {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  color: rgba(245, 244, 255, 0.7);
+}
+
+.journeys-header__secondary span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.journey-map {
+  position: relative;
+  width: 100%;
+  border: none;
+  border-radius: 1.5rem;
+  padding: 1.1rem 1.2rem 1.45rem;
+  text-align: left;
+  color: #f5f4ff;
+  background: linear-gradient(145deg, rgba(19, 24, 62, 0.85), rgba(9, 12, 40, 0.95));
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.journey-map:active {
+  transform: scale(0.98);
+}
+
+.journey-map:disabled {
+  cursor: default;
+  opacity: 0.85;
+}
+
+.journey-map__glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 18% 32%, rgba(255, 102, 196, 0.25), transparent 50%),
+    radial-gradient(circle at 82% 68%, rgba(77, 123, 255, 0.2), transparent 52%);
+  pointer-events: none;
+}
+
+.journey-map__line {
+  position: relative;
+  height: 68px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.journey-map__line-track {
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  height: 2px;
+  border-radius: 999px;
+  background: rgba(163, 174, 255, 0.35);
+  opacity: 0.7;
+}
+
+.journey-map__line-progress {
+  position: absolute;
+  left: 12%;
+  right: 12%;
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 102, 196, 1), rgba(77, 123, 255, 1));
+  transform-origin: left center;
+  transform: scaleX(0);
+  opacity: 0;
+}
+
+.journey-map__line-progress[data-state='idle'] {
+  opacity: 0.35;
+}
+
+.journey-map__line-progress[data-state='animating'] {
+  opacity: 1;
+  animation: journey-progress 1.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.journey-map__line-progress[data-state='complete'] {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.journey-map__plane {
+  position: absolute;
+  top: 50%;
+  left: 12%;
+  width: 48px;
+  height: 48px;
+  transform: translate(-50%, -50%) rotate(-6deg);
+  filter: drop-shadow(0 6px 16px rgba(255, 102, 196, 0.35));
+}
+
+.journey-map__plane svg {
+  width: 100%;
+  height: 100%;
+}
+
+.journey-map__plane[data-state='animating'] {
+  animation: plane-fly 1.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.journey-map__plane[data-state='complete'] {
+  left: 88%;
+  transform: translate(-50%, -50%) rotate(9deg);
+}
+
+.journey-map__plane--static {
+  animation: none !important;
+  left: 88% !important;
+  transform: translate(-50%, -50%) rotate(6deg) !important;
+}
+
+.journey-map__labels {
+  position: absolute;
+  top: 0.8rem;
+  left: 12%;
+  right: 12%;
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.8);
+}
+
+.journey-map__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 1rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  color: rgba(245, 244, 255, 0.82);
+}
+
+.journey-card {
+  display: grid;
+  gap: 1.4rem;
+  padding: 1.4rem;
+  border-radius: 1.5rem;
+  background: rgba(16, 21, 55, 0.6);
+  border: 1px solid rgba(163, 174, 255, 0.22);
+  box-shadow: 0 18px 40px rgba(4, 6, 22, 0.35);
+}
+
+@media (min-width: 720px) {
+  .journey-card {
+    grid-template-columns: minmax(220px, 0.85fr) minmax(0, 1fr);
+  }
+}
+
+.journey-card__media {
+  position: relative;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  min-height: 220px;
+  background-size: cover;
+  background-position: center;
+}
+
+.journey-card__photo {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.95;
+  transition: transform 0.6s ease;
+}
+
+.journey-card__media:hover .journey-card__photo {
+  transform: scale(1.03);
+}
+
+.journey-card__badge {
+  position: absolute;
+  bottom: 1rem;
+  left: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(5, 5, 22, 0.7);
+  border: 1px solid rgba(163, 174, 255, 0.35);
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.journey-card__badge-icon {
+  font-size: 1rem;
+}
+
+.journey-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.journey-card__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.journey-status {
+  padding: 0.25rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+}
+
+.journey-status--pending {
+  background: rgba(15, 20, 56, 0.75);
+  border: 1px solid rgba(163, 174, 255, 0.28);
+  color: rgba(245, 244, 255, 0.75);
+}
+
+.journey-status--arrived {
+  background: rgba(255, 102, 196, 0.18);
+  border: 1px solid rgba(255, 102, 196, 0.4);
+  color: #ffb2e2;
+}
+
+.journey-card__date {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  color: rgba(245, 244, 255, 0.75);
+}
+
+.journey-card__route {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 1.15rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+}
+
+.journey-card__transport {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+}
+
+.journey-card__transport span:first-child {
+  font-size: 1.1rem;
+}
+
+.journey-card__caption {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(245, 244, 255, 0.85);
+}
+
+.journey-card__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.journey-card__stat-label {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.6);
+}
+
+.journey-card__stat-value {
+  margin: 0.35rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.journey-prompts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.journey-prompts__locked {
+  margin: 0;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(163, 174, 255, 0.35);
+  background: rgba(12, 16, 48, 0.55);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  color: rgba(245, 244, 255, 0.7);
+}
+
+.journey-prompt {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1rem 1.1rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(163, 174, 255, 0.22);
+  background: rgba(11, 14, 40, 0.65);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.journey-prompt__question {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: rgba(245, 244, 255, 0.9);
+}
+
+.journey-prompt__input {
+  resize: vertical;
+  min-height: 4.5rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(163, 174, 255, 0.25);
+  background: rgba(6, 8, 24, 0.6);
+  color: #f5f4ff;
+  font-size: 0.95rem;
+  font-family: inherit;
+  line-height: 1.5;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.journey-prompt__input:focus {
+  outline: none;
+  border-color: rgba(255, 102, 196, 0.6);
+  box-shadow: 0 0 0 3px rgba(255, 102, 196, 0.18);
+}
+
+.journey-prompt__input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.journey-prompt__status {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.6);
+}
+
+.journeys-nav {
+  display: flex;
+  gap: 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.journeys-nav__button {
+  flex: 1;
+  border: 1px solid rgba(163, 174, 255, 0.28);
+  background: rgba(10, 14, 40, 0.75);
+  color: #f5f4ff;
+  border-radius: 999px;
+  padding: 0.9rem 1.2rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.journeys-nav__button:active {
+  transform: scale(0.97);
+}
+
+.journeys-nav__button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.journeys-nav__button--primary {
+  border: none;
+  background: linear-gradient(135deg, #ff66c4, #4d7bff);
+  color: #050516;
+  box-shadow: 0 12px 24px rgba(77, 123, 255, 0.25);
+}
+
+@keyframes journey-progress {
+  0% {
+    transform: scaleX(0);
+  }
+  100% {
+    transform: scaleX(1);
+  }
+}
+
+@keyframes plane-fly {
+  0% {
+    left: 12%;
+    transform: translate(-50%, -50%) rotate(-6deg);
+  }
+  100% {
+    left: 88%;
+    transform: translate(-50%, -50%) rotate(9deg);
+  }
+}
+
+@media (max-width: 520px) {
+  .journeys-header__row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .journeys-header__secondary {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .journey-map__line-progress[data-state='animating'] {
+    animation: none;
+    transform: scaleX(1);
+  }
+  .journey-map__plane[data-state='animating'] {
+    animation: none;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,10 +58,12 @@ function App() {
   const [sceneIndex, setSceneIndex] = useState(0)
   const currentSceneId = sceneOrder[sceneIndex]
 
-  const totalDistance = useMemo(
+  const totalJourneyDistance = useMemo(
     () => journeys.reduce((sum, journey) => sum + journey.distanceKm, 0),
     []
   )
+
+  const [distanceTraveled, setDistanceTraveled] = useState(0)
 
   const { responses, saveResponse } = useStoredJourneyResponses()
 
@@ -82,6 +84,7 @@ function App() {
 
   const restartExperience = () => {
     setSceneIndex(0)
+    setDistanceTraveled(0)
   }
 
   const sceneProps: SceneComponentProps = {
@@ -89,15 +92,20 @@ function App() {
     goToScene,
     onRestart: restartExperience,
     journeys,
-    totalDistance,
+    distanceTraveled,
+    totalJourneyDistance,
     responses,
     saveResponse,
+    setDistanceTraveled,
   }
 
   return (
     <div className={`app-shell scene-${currentSceneId}`}>
       {currentSceneId !== 'intro' && <GlobalStarfield />}
-      <DistanceHUD distanceKm={totalDistance} />
+      <DistanceHUD
+        distanceKm={distanceTraveled}
+        goalKm={totalJourneyDistance}
+      />
       <main className="scene-container">
         {renderScene(currentSceneId, sceneProps)}
       </main>

--- a/src/components/DistanceHUD.tsx
+++ b/src/components/DistanceHUD.tsx
@@ -1,5 +1,6 @@
 interface DistanceHUDProps {
   distanceKm: number
+  goalKm?: number
 }
 
 const formatDistance = (distanceKm: number) =>
@@ -7,11 +8,17 @@ const formatDistance = (distanceKm: number) =>
     maximumFractionDigits: 0,
   }).format(Math.round(distanceKm))
 
-export const DistanceHUD = ({ distanceKm }: DistanceHUDProps) => {
+export const DistanceHUD = ({ distanceKm, goalKm }: DistanceHUDProps) => {
+  const hasGoal = typeof goalKm === 'number'
   return (
     <div className="distance-hud" aria-live="polite">
       <span className="distance-hud__label">TOTAL DISTANCE</span>
-      <span className="distance-hud__value">{formatDistance(distanceKm)} km</span>
+      <span className="distance-hud__value">
+        {formatDistance(distanceKm)} km
+        {hasGoal ? (
+          <span className="distance-hud__goal"> / {formatDistance(goalKm!)} km</span>
+        ) : null}
+      </span>
     </div>
   )
 }

--- a/src/hooks/usePrefersReducedMotion.ts
+++ b/src/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react'
+
+const QUERY = '(prefers-reduced-motion: reduce)'
+
+export const usePrefersReducedMotion = () => {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+
+    return window.matchMedia(QUERY).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const mediaQuery = window.matchMedia(QUERY)
+    const handleChange = (event: MediaQueryListEvent) => {
+      setPrefersReducedMotion(event.matches)
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [])
+
+  return prefersReducedMotion
+}

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -1,37 +1,543 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+
 import { SceneLayout } from '../components/SceneLayout'
+import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
+import type { Journey } from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
+
+const PLANE_ANIMATION_MS = 1600
+
+const distanceFormatter = new Intl.NumberFormat('ja-JP', {
+  maximumFractionDigits: 0,
+})
+
+const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+})
+
+const timestampFormatter = new Intl.DateTimeFormat('ja-JP', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+})
+
+const formatDistance = (value: number) =>
+  distanceFormatter.format(Math.round(value))
+
+const getJourneyKey = (journey: Journey) =>
+  `${journey.date}-${journey.from}-${journey.to}`
+
+const formatJourneyDate = (value: string) => {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+
+  return dateFormatter.format(date)
+}
+
+const formatRecordedAt = (value?: string) => {
+  if (!value) {
+    return ''
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return ''
+  }
+
+  return timestampFormatter.format(date)
+}
+
+const transportMeta = {
+  plane: { label: 'AIR ROUTE', icon: '✈️' },
+  train: { label: 'TRAIN ROUTE', icon: '🚅' },
+  bus: { label: 'BUS ROUTE', icon: '🚌' },
+} as const
+
+const artBackgrounds: Record<string, string> = {
+  'night-sky-market':
+    'linear-gradient(145deg, rgba(30, 39, 89, 0.9), rgba(12, 17, 48, 0.95)), radial-gradient(circle at 20% 20%, rgba(255, 180, 255, 0.45), transparent 45%), radial-gradient(circle at 80% 70%, rgba(110, 190, 255, 0.35), transparent 55%)',
+  'valentine-neon':
+    'linear-gradient(160deg, rgba(55, 22, 76, 0.88), rgba(18, 16, 56, 0.95)), radial-gradient(circle at 78% 20%, rgba(255, 102, 196, 0.4), transparent 50%), radial-gradient(circle at 15% 70%, rgba(88, 147, 255, 0.4), transparent 55%)',
+  'stardust-finale':
+    'linear-gradient(150deg, rgba(18, 32, 78, 0.92), rgba(9, 12, 38, 0.95)), radial-gradient(circle at 30% 30%, rgba(255, 217, 140, 0.4), transparent 55%), radial-gradient(circle at 70% 75%, rgba(120, 225, 255, 0.35), transparent 50%)',
+}
+
+const getArtBackground = (artKey: string) =>
+  artBackgrounds[artKey] ??
+  'linear-gradient(150deg, rgba(20, 24, 60, 0.9), rgba(8, 10, 32, 0.95)), radial-gradient(circle at 30% 30%, rgba(255, 145, 245, 0.35), transparent 55%)'
 
 export const JourneysScene = ({
   onAdvance,
   journeys,
-  totalDistance,
+  distanceTraveled,
+  totalJourneyDistance,
+  responses,
+  saveResponse,
+  setDistanceTraveled,
 }: SceneComponentProps) => {
+  const prefersReducedMotion = usePrefersReducedMotion()
+
+  const cumulativeDistances = useMemo(() => {
+    const totals = [0]
+    journeys.forEach((journey) => {
+      totals.push(totals[totals.length - 1] + journey.distanceKm)
+    })
+    return totals
+  }, [journeys])
+
+  const computeCompletedCount = useCallback(
+    (distance: number) => {
+      let count = 0
+      for (let i = 0; i < journeys.length; i += 1) {
+        const threshold = cumulativeDistances[i + 1] ?? Number.POSITIVE_INFINITY
+        if (distance >= threshold) {
+          count = i + 1
+        } else {
+          break
+        }
+      }
+      return count
+    },
+    [journeys.length, cumulativeDistances]
+  )
+
+  const initialCompleted = computeCompletedCount(distanceTraveled)
+  const initialActiveIndex =
+    journeys.length === 0
+      ? 0
+      : Math.min(initialCompleted, journeys.length - 1)
+
+  const [completedCount, setCompletedCount] = useState(initialCompleted)
+  const [activeIndex, setActiveIndex] = useState(initialActiveIndex)
+  const [phase, setPhase] = useState<'idle' | 'animating' | 'arrived'>(
+    () => (initialCompleted > initialActiveIndex ? 'arrived' : 'idle')
+  )
+  const [animationToken, setAnimationToken] = useState(0)
+
+  const animationTimeoutRef = useRef<number | null>(null)
+
+  useEffect(
+    () => () => {
+      if (animationTimeoutRef.current !== null) {
+        window.clearTimeout(animationTimeoutRef.current)
+      }
+    },
+    []
+  )
+
+  useEffect(() => {
+    const derivedCompleted = computeCompletedCount(distanceTraveled)
+    setCompletedCount((prev) =>
+      prev === derivedCompleted ? prev : derivedCompleted
+    )
+  }, [distanceTraveled, computeCompletedCount])
+
+  useEffect(() => {
+    if (journeys.length === 0) {
+      setActiveIndex(0)
+      return
+    }
+
+    setActiveIndex((index) => Math.min(index, journeys.length - 1))
+  }, [journeys.length])
+
+  useEffect(() => {
+    if (phase === 'animating') {
+      return
+    }
+
+    const hasArrived = activeIndex < completedCount
+    const nextPhase = hasArrived ? 'arrived' : 'idle'
+    if (nextPhase !== phase) {
+      setPhase(nextPhase)
+    }
+  }, [activeIndex, completedCount, phase])
+
+  const completedDistance =
+    cumulativeDistances[Math.min(completedCount, cumulativeDistances.length - 1)] ?? 0
+
+  useEffect(() => {
+    setDistanceTraveled(completedDistance)
+  }, [completedDistance, setDistanceTraveled])
+
+  const currentJourney = journeys[activeIndex]
+  const currentJourneyKey = currentJourney ? getJourneyKey(currentJourney) : ''
+  const isCurrentCompleted = activeIndex < completedCount
+
+  const currentDistance = currentJourney?.distanceKm ?? 0
+  const distanceBeforeCurrent =
+    cumulativeDistances[Math.min(activeIndex, cumulativeDistances.length - 1)] ?? 0
+  const distanceAfterCurrent =
+    cumulativeDistances[Math.min(activeIndex + 1, cumulativeDistances.length - 1)] ??
+    distanceBeforeCurrent + currentDistance
+
+  const progressPercent = totalJourneyDistance
+    ? Math.min(100, Math.max(0, (completedDistance / totalJourneyDistance) * 100))
+    : 0
+
+  const activeJourneyResponses = useMemo(
+    () =>
+      responses.filter((entry) => entry.journeyKey === currentJourneyKey),
+    [responses, currentJourneyKey]
+  )
+
+  const responseByPrompt = useMemo(() => {
+    const map = new Map<string, string>()
+    activeJourneyResponses.forEach((entry) => {
+      map.set(entry.prompt, entry.answer)
+    })
+    return map
+  }, [activeJourneyResponses])
+
+  const recordedAtByPrompt = useMemo(() => {
+    const map = new Map<string, string>()
+    activeJourneyResponses.forEach((entry) => {
+      map.set(entry.prompt, entry.recordedAt)
+    })
+    return map
+  }, [activeJourneyResponses])
+
+  const [draftAnswers, setDraftAnswers] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    if (!currentJourney) {
+      setDraftAnswers({})
+      return
+    }
+
+    const next: Record<string, string> = {}
+    currentJourney.prompts.forEach((prompt) => {
+      next[prompt.q] = responseByPrompt.get(prompt.q) ?? ''
+    })
+
+    setDraftAnswers(next)
+  }, [currentJourney, responseByPrompt])
+
+  const handleLaunch = () => {
+    if (!currentJourney || phase === 'animating') {
+      return
+    }
+
+    const duration = prefersReducedMotion ? 0 : PLANE_ANIMATION_MS
+    const isReplay = isCurrentCompleted
+
+    setAnimationToken((token) => token + 1)
+
+    if (duration === 0) {
+      if (!isReplay) {
+        setCompletedCount((count) => Math.max(count, activeIndex + 1))
+      }
+      setPhase('arrived')
+      return
+    }
+
+    setPhase('animating')
+    if (animationTimeoutRef.current !== null) {
+      window.clearTimeout(animationTimeoutRef.current)
+    }
+
+    animationTimeoutRef.current = window.setTimeout(() => {
+      animationTimeoutRef.current = null
+      if (!isReplay) {
+        setCompletedCount((count) => Math.max(count, activeIndex + 1))
+      }
+      setPhase('arrived')
+    }, duration)
+  }
+
+  const handlePrevJourney = () => {
+    if (activeIndex === 0) {
+      return
+    }
+
+    if (animationTimeoutRef.current !== null) {
+      window.clearTimeout(animationTimeoutRef.current)
+      animationTimeoutRef.current = null
+    }
+
+    setActiveIndex((index) => Math.max(index - 1, 0))
+  }
+
+  const handleNextJourney = () => {
+    if (!isCurrentCompleted) {
+      return
+    }
+
+    if (activeIndex === journeys.length - 1) {
+      onAdvance()
+      return
+    }
+
+    if (animationTimeoutRef.current !== null) {
+      window.clearTimeout(animationTimeoutRef.current)
+      animationTimeoutRef.current = null
+    }
+
+    setActiveIndex((index) => Math.min(index + 1, journeys.length - 1))
+  }
+
+  const handleAnswerChange = (prompt: string, value: string) => {
+    if (!currentJourney || !isCurrentCompleted) {
+      return
+    }
+
+    setDraftAnswers((prev) => ({ ...prev, [prompt]: value }))
+    saveResponse({
+      journeyKey: currentJourneyKey,
+      prompt,
+      answer: value,
+    })
+  }
+
+  if (!currentJourney) {
+    return (
+      <SceneLayout
+        eyebrow="Journeys"
+        title="移動演出と思い出ギャラリー"
+        description="東京⇄福岡の移動をSVGアニメで描写しつつ、写真とキャプション、質問入力を組み合わせるハブシーンです。"
+      >
+        <p className="scene-note">
+          まだ旅のデータが登録されていません。JSONを整備したら、ここに移動演出と質問カードが並びます。
+        </p>
+      </SceneLayout>
+    )
+  }
+
+  const transport = transportMeta[currentJourney.transport]
+  const planeState: 'idle' | 'animating' | 'complete' =
+    phase === 'animating'
+      ? 'animating'
+      : isCurrentCompleted
+        ? 'complete'
+        : 'idle'
+
+  const progressState: 'idle' | 'animating' | 'complete' = planeState
+
+  const remainingDistance = Math.max(totalJourneyDistance - completedDistance, 0)
+
+  const statusLabel = (() => {
+    if (phase === 'animating') {
+      return '移動中…'
+    }
+    if (isCurrentCompleted) {
+      return '到着済み — 記録を残そう'
+    }
+    return `${currentJourney.from} → ${currentJourney.to} を開始 (タップ)`
+  })()
+
+  const planeClassName = [
+    'journey-map__plane',
+    prefersReducedMotion && planeState === 'complete'
+      ? 'journey-map__plane--static'
+      : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
     <SceneLayout
       eyebrow="Journeys"
       title="移動演出と思い出ギャラリー"
-      description="東京⇄福岡の移動をSVGアニメで描写しつつ、写真とキャプション、質問入力を組み合わせるハブシーンです。"
-      onAdvance={onAdvance}
-      advanceLabel="次のシーンへ"
+      description="東京⇄福岡の移動をタップで辿り、到着ごとに写真と質問へ答えを残していきます。"
     >
-      <div className="stat-grid">
-        <div>
-          <p className="stat-label">登録予定の移動イベント</p>
-          <p className="stat-value">{journeys.length}件</p>
+      <div className="journeys-experience">
+        <header className="journeys-header">
+          <div className="journeys-header__row">
+            <span className="journeys-header__label">
+              JOURNEY {activeIndex + 1}/{journeys.length}
+            </span>
+            <span className="journeys-header__distance">
+              累計 {formatDistance(completedDistance)} km
+            </span>
+          </div>
+          <div className="journeys-progress-bar" aria-hidden="true">
+            <div
+              className="journeys-progress-bar__fill"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <div className="journeys-header__secondary">
+            <span>
+              残り {formatDistance(remainingDistance)} km
+            </span>
+            <span>
+              {isCurrentCompleted
+                ? `到着済み: ${formatDistance(distanceAfterCurrent)} km`
+                : `出発前: ${formatDistance(distanceBeforeCurrent)} km`}
+            </span>
+          </div>
+        </header>
+
+        <button
+          type="button"
+          className="journey-map"
+          onClick={handleLaunch}
+          disabled={phase === 'animating'}
+          aria-live="polite"
+          aria-label={`${currentJourney.from}から${currentJourney.to}への移動を開始`}
+        >
+          <span className="journey-map__glow" aria-hidden="true" />
+          <div className="journey-map__line" aria-hidden="true">
+            <span className="journey-map__line-track" />
+            <span
+              key={`progress-${activeIndex}-${animationToken}-${progressState}`}
+              className="journey-map__line-progress"
+              data-state={progressState}
+            />
+          </div>
+          <span
+            key={`plane-${activeIndex}-${animationToken}-${planeState}`}
+            className={planeClassName}
+            data-state={planeState}
+            aria-hidden="true"
+          >
+            <svg viewBox="0 0 60 32" role="img" aria-hidden="true">
+              <path
+                d="M2 14h24l8-10h7l-7 10h18l4 2-4 2H34l7 10h-7l-8-10H2l-2-2z"
+                fill="url(#planeGradient)"
+              />
+              <defs>
+                <linearGradient id="planeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+                  <stop offset="0%" stopColor="#ff66c4" />
+                  <stop offset="100%" stopColor="#4d7bff" />
+                </linearGradient>
+              </defs>
+            </svg>
+          </span>
+          <div className="journey-map__labels" aria-hidden="true">
+            <span>{currentJourney.from}</span>
+            <span>{currentJourney.to}</span>
+          </div>
+          <span className="journey-map__status">{statusLabel}</span>
+        </button>
+
+        <div className="journey-card">
+          <div
+            className="journey-card__media"
+            style={{ background: getArtBackground(currentJourney.artKey) }}
+          >
+            <img
+              className="journey-card__photo"
+              src={currentJourney.photoURL}
+              alt={`${currentJourney.from}から${currentJourney.to}の思い出写真`}
+              loading="lazy"
+            />
+            <span className="journey-card__badge">
+              <span className="journey-card__badge-icon" aria-hidden="true">
+                {transport.icon}
+              </span>
+              {transport.label}
+            </span>
+          </div>
+          <div className="journey-card__body">
+            <div className="journey-card__meta">
+              <span
+                className={`journey-status journey-status--${
+                  isCurrentCompleted ? 'arrived' : 'pending'
+                }`}
+              >
+                {isCurrentCompleted ? 'ARRIVED' : 'READY'}
+              </span>
+              <span className="journey-card__date">
+                {formatJourneyDate(currentJourney.date)}
+              </span>
+            </div>
+            <div className="journey-card__route">
+              <span className="journey-card__city">{currentJourney.from}</span>
+              <span className="journey-card__arrow" aria-hidden="true">
+                →
+              </span>
+              <span className="journey-card__city">{currentJourney.to}</span>
+            </div>
+            <div className="journey-card__transport">
+              <span>{transport.icon}</span>
+              <span>{transport.label}</span>
+              <span>{formatDistance(currentJourney.distanceKm)} km</span>
+            </div>
+            <p className="journey-card__caption">{currentJourney.caption}</p>
+            <div className="journey-card__stats">
+              <div>
+                <p className="journey-card__stat-label">今回の移動距離</p>
+                <p className="journey-card__stat-value">
+                  {formatDistance(currentJourney.distanceKm)} km
+                </p>
+              </div>
+              <div>
+                <p className="journey-card__stat-label">累計距離</p>
+                <p className="journey-card__stat-value">
+                  {formatDistance(
+                    isCurrentCompleted ? distanceAfterCurrent : distanceBeforeCurrent
+                  )}{' '}
+                  km
+                </p>
+              </div>
+            </div>
+            <div className="journey-prompts">
+              {!isCurrentCompleted ? (
+                <p className="journey-prompts__locked">
+                  フライトを完了すると質問が開きます。
+                </p>
+              ) : null}
+              {currentJourney.prompts.map((prompt) => {
+                const answer = draftAnswers[prompt.q] ?? ''
+                const recordedAt = recordedAtByPrompt.get(prompt.q)
+
+                return (
+                  <label className="journey-prompt" key={prompt.q}>
+                    <span className="journey-prompt__question">{prompt.q}</span>
+                    <textarea
+                      className="journey-prompt__input"
+                      value={answer}
+                      placeholder="ここに感じたことをメモ"
+                      onChange={(event) =>
+                        handleAnswerChange(prompt.q, event.currentTarget.value)
+                      }
+                      disabled={!isCurrentCompleted}
+                      rows={3}
+                    />
+                    <span className="journey-prompt__status">
+                      {recordedAt
+                        ? `記録: ${formatRecordedAt(recordedAt)}`
+                        : '未記録'}
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+          </div>
         </div>
-        <div>
-          <p className="stat-label">サンプル合計距離</p>
-          <p className="stat-value">{Math.round(totalDistance)} km</p>
-        </div>
+
+        <nav className="journeys-nav" aria-label="Journeys navigation">
+          <button
+            type="button"
+            className="journeys-nav__button"
+            onClick={handlePrevJourney}
+            disabled={activeIndex === 0}
+          >
+            前の旅へ
+          </button>
+          <button
+            type="button"
+            className="journeys-nav__button journeys-nav__button--primary"
+            onClick={handleNextJourney}
+            disabled={!isCurrentCompleted}
+          >
+            {activeIndex === journeys.length - 1 ? 'Messagesへ進む' : '次の移動へ'}
+          </button>
+        </nav>
       </div>
-      <p className="scene-note">
-        タップで進むたびに飛行機アイコンをアニメーションさせ、到着時に写真＋質問カードがスライド表示される構成を想定しています。
-      </p>
-      <ol className="scene-list">
-        <li>距離HUDは画面上部に固定し、シーン移動間でも値を共有。</li>
-        <li>回答はローカルストレージに保存し、Resultで固定表示。</li>
-        <li>クイズ用に距離ステートを他シーンから参照できるよう設計。</li>
-      </ol>
     </SceneLayout>
   )
 }

--- a/src/scenes/ResultScene.tsx
+++ b/src/scenes/ResultScene.tsx
@@ -7,7 +7,7 @@ const formatNumber = (value: number) =>
 export const ResultScene = ({
   onRestart,
   journeys,
-  totalDistance,
+  distanceTraveled,
   responses,
 }: SceneComponentProps) => {
   const recordedResponses = responses.length
@@ -23,7 +23,7 @@ export const ResultScene = ({
       <div className="result-grid">
         <div className="result-card">
           <p className="result-label">TRAVELLED</p>
-          <p className="result-value">{formatNumber(Math.round(totalDistance))} km</p>
+          <p className="result-value">{formatNumber(Math.round(distanceTraveled))} km</p>
         </div>
         <div className="result-card">
           <p className="result-label">JOURNEYS</p>

--- a/src/types/scenes.ts
+++ b/src/types/scenes.ts
@@ -19,9 +19,16 @@ export interface SceneComponentProps {
   goToScene: (scene: SceneId) => void
   onRestart: () => void
   journeys: Journey[]
-  totalDistance: number
+  /**
+   * Sum of the journey distances that have been experienced so far.
+   * Displayed in the persistent HUD and reused by later scenes (quizzes/result).
+   */
+  distanceTraveled: number
+  /** Total distance if every journey in the dataset is completed. */
+  totalJourneyDistance: number
   responses: JourneyPromptResponse[]
   saveResponse: (payload: SaveJourneyResponsePayload) => void
+  setDistanceTraveled: (value: number) => void
 }
 
 export const sceneOrder: SceneId[] = [


### PR DESCRIPTION
## Summary
- replace the Journeys scene with an interactive travel flow that animates each route, reveals journey cards with media/prompts, and stores answers locally
- track travelled distance globally so the HUD and result scene reflect cumulative progress across the experience
- extend styling and utilities, including a reduced-motion hook, to support the new Journeys UI and HUD goal display
- fix the journey completion sync loop so progress no longer resets when the global travel distance updates mid-animation

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce4b84aa94832f9360119625f024f4