### PR TITLE
Refine journeys orchestration and meetups gallery

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -781,6 +781,22 @@
   color: #f5f4ff;
 }
 
+.journeys-header__title {
+  margin: 0;
+  font-size: clamp(1.15rem, 4.2vw, 1.6rem);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: rgba(245, 244, 255, 0.92);
+}
+
+.journeys-header__step {
+  margin: -0.25rem 0 0;
+  font-size: 0.82rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+}
+
 .journeys-progress-bar {
   position: relative;
   height: 6px;
@@ -797,6 +813,29 @@
   transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.journeys-step-indicator {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.15rem;
+}
+
+.journeys-step-indicator__dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: rgba(163, 174, 255, 0.28);
+  transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.journeys-step-indicator__dot.is-complete {
+  background: rgba(255, 102, 196, 0.4);
+}
+
+.journeys-step-indicator__dot.is-current {
+  background: linear-gradient(135deg, #ff66c4, #4d7bff);
+  transform: scale(1.1);
+}
+
 .journeys-header__secondary {
   display: flex;
   justify-content: space-between;
@@ -809,6 +848,12 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+}
+
+.journeys-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .journey-map {
@@ -1054,6 +1099,22 @@
   color: rgba(245, 244, 255, 0.7);
 }
 
+.journey-card__city {
+  font-weight: 600;
+}
+
+.journey-card__arrow {
+  opacity: 0.75;
+}
+
+.journey-card__episode-title {
+  margin: 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: rgba(245, 244, 255, 0.92);
+}
+
 .journey-card__transport span:first-child {
   font-size: 1.1rem;
 }
@@ -1091,6 +1152,10 @@
   gap: 1rem;
 }
 
+.journey-prompts--single {
+  gap: 1.25rem;
+}
+
 .journey-prompts__locked {
   margin: 0;
   padding: 0.85rem 1rem;
@@ -1117,6 +1182,12 @@
   font-weight: 600;
   font-size: 0.95rem;
   color: rgba(245, 244, 255, 0.9);
+}
+
+.journey-prompt__helper {
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: rgba(245, 244, 255, 0.65);
 }
 
 .journey-prompt__input {
@@ -1149,6 +1220,31 @@
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: rgba(245, 244, 255, 0.6);
+}
+
+.journey-prompt__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.journey-prompt__toggle {
+  border: none;
+  background: rgba(77, 123, 255, 0.18);
+  color: #f5f4ff;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.journey-prompt__toggle:active {
+  transform: scale(0.98);
 }
 
 .journeys-nav {
@@ -1421,6 +1517,199 @@
   font-size: 0.85rem;
   letter-spacing: 0.05em;
   color: rgba(245, 244, 255, 0.85);
+}
+
+/* Meetups gallery */
+.meetups-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.meetups-art {
+  position: relative;
+  --meetups-accent: rgba(255, 102, 196, 0.45);
+  --meetups-ambient: rgba(12, 16, 40, 0.7);
+  border-radius: 1.6rem;
+  padding: 1.6rem;
+  min-height: 320px;
+  overflow: hidden;
+  box-shadow: 0 20px 48px rgba(6, 8, 30, 0.45);
+}
+
+.meetups-art__glow {
+  position: absolute;
+  inset: -20%;
+  background:
+    radial-gradient(circle at 24% 30%, var(--meetups-accent), transparent 55%),
+    radial-gradient(circle at 82% 70%, rgba(255, 255, 255, 0.22), transparent 58%);
+  opacity: 0.85;
+  filter: blur(0px);
+  pointer-events: none;
+}
+
+.meetups-art__photo {
+  position: absolute;
+  top: 12%;
+  right: 6%;
+  width: min(48%, 240px);
+  height: auto;
+  max-height: 68%;
+  border-radius: 1.3rem;
+  object-fit: cover;
+  box-shadow: 0 16px 44px rgba(6, 8, 30, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.meetups-art__header {
+  position: relative;
+  z-index: 1;
+  max-width: min(60%, 320px);
+  color: rgba(245, 244, 255, 0.95);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.meetups-art__month {
+  font-size: 0.72rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+}
+
+.meetups-art__title {
+  margin: 0;
+  font-size: clamp(1.3rem, 5vw, 1.65rem);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.meetups-art__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: rgba(245, 244, 255, 0.75);
+}
+
+.meetups-notes {
+  padding: 1.4rem;
+  border-radius: 1.4rem;
+  background: var(--meetups-ambient, rgba(12, 16, 40, 0.65));
+  border: 1px solid rgba(163, 174, 255, 0.28);
+  box-shadow: 0 18px 44px rgba(6, 8, 30, 0.38);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.meetups-notes__description {
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.7;
+  color: rgba(245, 244, 255, 0.85);
+}
+
+.meetups-notes__list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  color: rgba(245, 244, 255, 0.8);
+}
+
+.meetups-notes__footnote {
+  margin: 0;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: rgba(245, 244, 255, 0.6);
+}
+
+.meetups-controls {
+  display: flex;
+  gap: 0.85rem;
+}
+
+.meetups-controls__button {
+  flex: 1;
+  border: 1px solid rgba(163, 174, 255, 0.32);
+  background: rgba(12, 18, 44, 0.78);
+  color: rgba(245, 244, 255, 0.88);
+  border-radius: 999px;
+  padding: 0.85rem 1.1rem;
+  font-size: 0.88rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.meetups-controls__button:active {
+  transform: scale(0.98);
+}
+
+.meetups-controls__button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.meetups-controls__button--primary {
+  border: none;
+  background: linear-gradient(135deg, #ff66c4, #4d7bff);
+  color: #050516;
+  box-shadow: 0 14px 28px rgba(77, 123, 255, 0.28);
+}
+
+.meetups-timeline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.meetups-timeline__item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(124, 147, 255, 0.28);
+  background: rgba(12, 18, 44, 0.62);
+  color: rgba(245, 244, 255, 0.76);
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+}
+
+.meetups-timeline__item.is-active {
+  border-color: rgba(255, 102, 196, 0.55);
+  color: rgba(245, 244, 255, 0.94);
+  transform: translateY(-4px);
+}
+
+.meetups-timeline__month {
+  font-size: 0.72rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+}
+
+.meetups-timeline__label {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+@media (max-width: 540px) {
+  .meetups-art__photo {
+    position: static;
+    width: 100%;
+    max-height: none;
+    margin-top: 1.4rem;
+  }
+
+  .meetups-art__header {
+    max-width: none;
+  }
 }
 
 .messages-timeline__distance {

--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -1,42 +1,159 @@
 import type { Journey } from '../types/journey'
 
-const defaultPrompts = [
-  'このときどう思った？',
-  '一番印象に残った瞬間は？',
+type JourneyInput = Omit<Journey, 'distanceKm'>
+
+const journeyDefinitions: JourneyInput[] = [
+  {
+    id: 'journey-2023-autumn',
+    title: '空フェス夜市が始まった夜',
+    date: '2023-10-14',
+    steps: [
+      {
+        id: '2023-autumn-flight',
+        type: 'move',
+        from: 'Tokyo',
+        to: 'Fukuoka',
+        transport: 'plane',
+        distanceKm: 1080,
+        artKey: 'night-sky-market',
+        description: '羽田からネオン色の夜市へ。機内アナウンスが幕開けを告げた。',
+      },
+      {
+        id: '2023-autumn-market',
+        type: 'episode',
+        title: '空フェス夜市で再会',
+        caption:
+          '提灯が揺れるアーケードで、互いの歩幅が自然に揃った。写真を撮るたびに笑い声が重なる。',
+        artKey: 'night-sky-market',
+        media: {
+          src: 'https://images.placeholders.dev/?width=640&height=900&text=Night+Market',
+          alt: '夜市のネオンとふたりの影が写る写真',
+          objectPosition: 'center top',
+        },
+      },
+      {
+        id: '2023-autumn-question-feeling',
+        type: 'question',
+        prompt: 'このときどう思った？',
+        placeholder: '屋台の匂いや風のあたたかさを、好きな言葉で書き残そう。',
+        helper: '回答はローカルに保存され、Resultでそのまま表示されます。',
+      },
+      {
+        id: '2023-autumn-question-highlight',
+        type: 'question',
+        prompt: '一番印象に残った瞬間は？',
+        placeholder: 'ネオンが弾けた瞬間、ふたりで見た景色は？',
+      },
+    ],
+  },
+  {
+    id: 'journey-2024-valentine',
+    title: 'バレンタイン前夜の逆遠征',
+    date: '2024-02-11',
+    steps: [
+      {
+        id: '2024-valentine-flight',
+        type: 'move',
+        from: 'Fukuoka',
+        to: 'Tokyo',
+        transport: 'plane',
+        distanceKm: 1080,
+        artKey: 'valentine-neon',
+        description: '福岡の夜風を背に、チョコレートを抱えて羽田へ向かう。',
+      },
+      {
+        id: '2024-valentine-city',
+        type: 'episode',
+        title: '東京の夜景と秘密の計画',
+        caption:
+          '展望デッキから眺める街はピンクとブルーのグラデーション。明日のサプライズ手順をこっそり指差しで確認した。',
+        artKey: 'valentine-neon',
+        media: {
+          src: 'https://images.placeholders.dev/?width=640&height=900&text=Tokyo+Neon',
+          alt: '東京の夜景と渡す予定のチョコレート',
+        },
+      },
+      {
+        id: '2024-valentine-question-feeling',
+        type: 'question',
+        prompt: 'このときどう思った？',
+        placeholder: '展望デッキで考えていたこと、胸の高鳴りを書き残そう。',
+      },
+      {
+        id: '2024-valentine-question-highlight',
+        type: 'question',
+        prompt: '一番印象に残った瞬間は？',
+        placeholder: 'チョコを渡すタイミング？それとも夜景？',
+      },
+    ],
+  },
+  {
+    id: 'journey-2024-summer',
+    title: '流星群と夏祭りのフィナーレ',
+    date: '2024-07-27',
+    steps: [
+      {
+        id: '2024-summer-flight',
+        type: 'move',
+        from: 'Tokyo',
+        to: 'Fukuoka',
+        transport: 'plane',
+        distanceKm: 1080,
+        artKey: 'stardust-finale',
+        description: '夏の雲を突き抜けて福岡へ。コックピットの窓に夕焼けが反射する。',
+      },
+      {
+        id: '2024-summer-festival',
+        type: 'episode',
+        title: '夏祭りと流星のシャワー',
+        caption:
+          '浴衣の袖が触れるたびに、屋台の光がぼやける。流星群を浴びながら、最後の再会をゆっくり噛み締めた。',
+        artKey: 'stardust-finale',
+        media: {
+          src: 'https://images.placeholders.dev/?width=640&height=900&text=Summer+Festival',
+          alt: '夜空に流れる流星群と夏祭りの提灯',
+          objectPosition: 'center',
+        },
+      },
+      {
+        id: '2024-summer-bonus',
+        type: 'episode',
+        title: '夜風に溶ける手紙',
+        caption:
+          '屋台の裏で交換した手紙。封を開ける指先が震えて、笑いながら握り直した。',
+        artKey: 'stardust-finale',
+        media: {
+          src: 'https://images.placeholders.dev/?width=640&height=900&text=Letter+Exchange',
+          alt: 'ライトアップされた川辺と手紙の封筒',
+          objectPosition: 'center bottom',
+        },
+      },
+      {
+        id: '2024-summer-question-feeling',
+        type: 'question',
+        prompt: 'このときどう思った？',
+        placeholder: '流星の瞬きとリンクした感情をメモ。',
+      },
+      {
+        id: '2024-summer-question-highlight',
+        type: 'question',
+        prompt: '一番印象に残った瞬間は？',
+        placeholder: '夏の夜を締めくくったシーンを書き残そう。',
+      },
+    ],
+  },
 ]
 
-export const journeys: Journey[] = [
-  {
-    date: '2023-10-14',
-    from: 'Tokyo',
-    to: 'Fukuoka',
-    transport: 'plane',
-    caption: '秋の空フェスをきっかけに、ふたりの距離が一気に縮まった旅のはじまり。',
-    photoURL: 'https://images.placeholders.dev/?width=600&height=900&text=Fukuoka+Arrival',
-    artKey: 'night-sky-market',
-    distanceKm: 1080,
-    prompts: defaultPrompts.map((q) => ({ q })),
-  },
-  {
-    date: '2024-02-11',
-    from: 'Fukuoka',
-    to: 'Tokyo',
-    transport: 'plane',
-    caption: 'バレンタイン前に東京を案内。夜景とチョコと秘密の計画。',
-    photoURL: 'https://images.placeholders.dev/?width=600&height=900&text=Tokyo+Night',
-    artKey: 'valentine-neon',
-    distanceKm: 1080,
-    prompts: defaultPrompts.map((q) => ({ q })),
-  },
-  {
-    date: '2024-07-27',
-    from: 'Tokyo',
-    to: 'Fukuoka',
-    transport: 'plane',
-    caption: '夏祭りと流星群。ふたりの一年を締めくくる、とっておきの再会。',
-    photoURL: 'https://images.placeholders.dev/?width=600&height=900&text=Summer+Festival',
-    artKey: 'stardust-finale',
-    distanceKm: 1080,
-    prompts: defaultPrompts.map((q) => ({ q })),
-  },
-]
+export const journeys: Journey[] = journeyDefinitions.map((journey) => {
+  const distanceKm = journey.steps.reduce((total, step) => {
+    if (step.type === 'move') {
+      return total + step.distanceKm
+    }
+    return total
+  }, 0)
+
+  return {
+    ...journey,
+    distanceKm,
+  }
+})

--- a/src/data/meetups.ts
+++ b/src/data/meetups.ts
@@ -1,0 +1,109 @@
+export interface MeetupPage {
+  id: string
+  monthLabel: string
+  title: string
+  subtitle: string
+  description: string
+  memoryPoints: string[]
+  background: string
+  accent: string
+  ambient: string
+  photo: {
+    src: string
+    alt: string
+    objectPosition?: string
+  }
+  footnote?: string
+}
+
+export const meetupPages: MeetupPage[] = [
+  {
+    id: '2023-10-fukuoka',
+    monthLabel: '2023.10 Fukuoka',
+    title: '空フェス夜市アフター',
+    subtitle: 'ネオンの余韻と唐揚げの香りが混ざった夜。',
+    description:
+      '屋台の裏通りで撮った一枚。提灯の光に照らされた笑顔が、旅の始まりを象徴するページ。',
+    memoryPoints: [
+      'ネオン看板の前で30秒セルフタイマー',
+      '明太バター唐揚げとラムネをシェア',
+      '宿へ帰る坂道で手の温度を確認',
+    ],
+    background:
+      'radial-gradient(circle at 18% 24%, rgba(255, 102, 196, 0.36), transparent 52%), radial-gradient(circle at 78% 68%, rgba(96, 148, 255, 0.35), transparent 55%), linear-gradient(145deg, rgba(23, 22, 58, 0.95), rgba(12, 16, 46, 0.96))',
+    accent: 'rgba(255, 153, 220, 0.65)',
+    ambient: 'rgba(10, 14, 40, 0.65)',
+    photo: {
+      src: 'https://images.placeholders.dev/?width=720&height=900&text=Night+Market+After',
+      alt: 'ネオンが灯る夜市の路地で肩を寄せ合うふたり',
+      objectPosition: 'center top',
+    },
+    footnote: '写真はiPhone 16 Proで撮影。色調補正なしのまま掲載。',
+  },
+  {
+    id: '2023-12-letter',
+    monthLabel: '2023.12 Tokyo',
+    title: '年末の手紙交換',
+    subtitle: '手袋越しに封筒を渡した、静かな冬の夜。',
+    description:
+      'イルミネーションの河川敷で手紙を交換した瞬間。雪は降らなかったけれど、吐息が白く揺れていた。',
+    memoryPoints: [
+      '橋の欄干をライトで照らして撮影',
+      '手紙を読む前に深呼吸3回',
+      'その場で録音した音声メモを後日Resultで再生予定',
+    ],
+    background:
+      'radial-gradient(circle at 22% 18%, rgba(120, 190, 255, 0.42), transparent 58%), radial-gradient(circle at 72% 78%, rgba(255, 220, 255, 0.35), transparent 55%), linear-gradient(160deg, rgba(16, 26, 66, 0.95), rgba(8, 12, 40, 0.96))',
+    accent: 'rgba(120, 190, 255, 0.7)',
+    ambient: 'rgba(6, 10, 30, 0.72)',
+    photo: {
+      src: 'https://images.placeholders.dev/?width=720&height=900&text=Winter+Letter',
+      alt: '冬の河川敷で封筒を差し出す手元のアップ',
+      objectPosition: 'center',
+    },
+  },
+  {
+    id: '2024-02-tokyo',
+    monthLabel: '2024.02 Tokyo',
+    title: 'バレンタイン前夜の作戦会議',
+    subtitle: '展望デッキとホテルラウンジをハシゴした夜。',
+    description:
+      '街を見下ろしながら翌日の段取りを決めたページ。手帳とチョコのリボンが写り込んでいるのがポイント。',
+    memoryPoints: [
+      '展望デッキのガラス越しに撮影して反射を活かす',
+      'サプライズ手順を箇条書きで確認',
+      'ラウンジで頼んだココアを飲み干すまでの所要時間は4分',
+    ],
+    background:
+      'radial-gradient(circle at 82% 22%, rgba(255, 102, 196, 0.45), transparent 52%), radial-gradient(circle at 18% 78%, rgba(88, 147, 255, 0.35), transparent 55%), linear-gradient(165deg, rgba(42, 20, 68, 0.92), rgba(14, 16, 52, 0.96))',
+    accent: 'rgba(255, 102, 196, 0.6)',
+    ambient: 'rgba(18, 16, 46, 0.72)',
+    photo: {
+      src: 'https://images.placeholders.dev/?width=720&height=900&text=Valentine+Prep',
+      alt: '東京の夜景と並ぶ手帳とチョコレート',
+    },
+  },
+  {
+    id: '2024-07-finale',
+    monthLabel: '2024.07 Fukuoka',
+    title: '流星群フィナーレ',
+    subtitle: '花火と流星のダブルフィナーレを浴びた晩。',
+    description:
+      '夏祭りの余韻を閉じ込めたラストページ。川辺の風と遠くの歓声を思い出すように、光の粒を散りばめた。',
+    memoryPoints: [
+      '長時間露光で流星を3本キャッチ',
+      '花火の音が届くまでのタイムラグを計測',
+      '帰りのタクシーでResultの構成案を決定',
+    ],
+    background:
+      'radial-gradient(circle at 26% 24%, rgba(255, 217, 140, 0.45), transparent 55%), radial-gradient(circle at 74% 76%, rgba(120, 225, 255, 0.4), transparent 58%), linear-gradient(150deg, rgba(18, 32, 78, 0.94), rgba(9, 12, 38, 0.95))',
+    accent: 'rgba(255, 217, 140, 0.65)',
+    ambient: 'rgba(10, 16, 40, 0.68)',
+    photo: {
+      src: 'https://images.placeholders.dev/?width=720&height=900&text=Stardust+Finale',
+      alt: '川辺で流星群と花火を見上げるふたりのシルエット',
+      objectPosition: 'center bottom',
+    },
+    footnote: 'Result画面ではここで取得した距離とリンクさせてハイライト演出を予定。',
+  },
+]

--- a/src/hooks/useStoredJourneyResponses.ts
+++ b/src/hooks/useStoredJourneyResponses.ts
@@ -28,7 +28,8 @@ const readFromStorage = (): JourneyPromptResponse[] => {
     return parsed.filter(
       (entry) =>
         typeof entry === 'object' &&
-        typeof entry.journeyKey === 'string' &&
+        typeof entry.journeyId === 'string' &&
+        typeof entry.stepId === 'string' &&
         typeof entry.prompt === 'string' &&
         typeof entry.answer === 'string' &&
         typeof entry.recordedAt === 'string'
@@ -61,7 +62,10 @@ export const useStoredJourneyResponses = () => {
       setResponses((prev) => {
         const filtered = prev.filter(
           (entry) =>
-            !(entry.journeyKey === payload.journeyKey && entry.prompt === payload.prompt)
+            !(
+              entry.journeyId === payload.journeyId &&
+              entry.stepId === payload.stepId
+            )
         )
 
         const updated: JourneyPromptResponse = {

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -8,10 +8,17 @@ import {
 
 import { SceneLayout } from '../components/SceneLayout'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
-import type { Journey } from '../types/journey'
+import type {
+  Journey,
+  JourneyEpisodeStep,
+  JourneyMoveStep,
+  JourneyQuestionStep,
+  JourneyStep,
+} from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
 
 const PLANE_ANIMATION_MS = 1600
+const COMPLETION_EPSILON = 0.5
 
 const distanceFormatter = new Intl.NumberFormat('ja-JP', {
   maximumFractionDigits: 0,
@@ -33,9 +40,6 @@ const timestampFormatter = new Intl.DateTimeFormat('ja-JP', {
 
 const formatDistance = (value: number) =>
   distanceFormatter.format(Math.round(value))
-
-const getJourneyKey = (journey: Journey) =>
-  `${journey.date}-${journey.from}-${journey.to}`
 
 const formatJourneyDate = (value: string) => {
   const date = new Date(value)
@@ -67,16 +71,65 @@ const transportMeta = {
 
 const artBackgrounds: Record<string, string> = {
   'night-sky-market':
-    'linear-gradient(145deg, rgba(30, 39, 89, 0.9), rgba(12, 17, 48, 0.95)), radial-gradient(circle at 20% 20%, rgba(255, 180, 255, 0.45), transparent 45%), radial-gradient(circle at 80% 70%, rgba(110, 190, 255, 0.35), transparent 55%)',
+    'linear-gradient(145deg, rgba(30, 39, 89, 0.92), rgba(12, 17, 48, 0.96)), radial-gradient(circle at 20% 20%, rgba(255, 196, 255, 0.45), transparent 48%), radial-gradient(circle at 78% 70%, rgba(110, 190, 255, 0.38), transparent 55%)',
   'valentine-neon':
-    'linear-gradient(160deg, rgba(55, 22, 76, 0.88), rgba(18, 16, 56, 0.95)), radial-gradient(circle at 78% 20%, rgba(255, 102, 196, 0.4), transparent 50%), radial-gradient(circle at 15% 70%, rgba(88, 147, 255, 0.4), transparent 55%)',
+    'linear-gradient(160deg, rgba(55, 22, 76, 0.9), rgba(18, 16, 56, 0.96)), radial-gradient(circle at 82% 18%, rgba(255, 102, 196, 0.45), transparent 50%), radial-gradient(circle at 14% 78%, rgba(88, 147, 255, 0.38), transparent 52%)',
   'stardust-finale':
-    'linear-gradient(150deg, rgba(18, 32, 78, 0.92), rgba(9, 12, 38, 0.95)), radial-gradient(circle at 30% 30%, rgba(255, 217, 140, 0.4), transparent 55%), radial-gradient(circle at 70% 75%, rgba(120, 225, 255, 0.35), transparent 50%)',
+    'linear-gradient(150deg, rgba(18, 32, 78, 0.92), rgba(9, 12, 38, 0.95)), radial-gradient(circle at 32% 28%, rgba(255, 217, 140, 0.45), transparent 55%), radial-gradient(circle at 72% 72%, rgba(120, 225, 255, 0.4), transparent 50%)',
 }
 
-const getArtBackground = (artKey: string) =>
-  artBackgrounds[artKey] ??
-  'linear-gradient(150deg, rgba(20, 24, 60, 0.9), rgba(8, 10, 32, 0.95)), radial-gradient(circle at 30% 30%, rgba(255, 145, 245, 0.35), transparent 55%)'
+const defaultArtBackground =
+  'linear-gradient(150deg, rgba(20, 24, 60, 0.92), rgba(8, 10, 32, 0.95))'
+
+const getArtBackground = (key: string) => artBackgrounds[key] ?? defaultArtBackground
+
+const stepTypeLabel: Record<JourneyStep['type'], string> = {
+  move: '移動',
+  episode: '思い出',
+  question: '記録',
+}
+
+type MoveMeta = {
+  stepId: string
+  journeyId: string
+  distanceKm: number
+  cumulativeBefore: number
+  cumulativeAfter: number
+}
+
+const buildMoveMetas = (journeyList: Journey[]): MoveMeta[] => {
+  const result: MoveMeta[] = []
+  let running = 0
+
+  journeyList.forEach((journey) => {
+    journey.steps.forEach((step) => {
+      if (step.type === 'move') {
+        const before = running
+        running += step.distanceKm
+        result.push({
+          stepId: step.id,
+          journeyId: journey.id,
+          distanceKm: step.distanceKm,
+          cumulativeBefore: before,
+          cumulativeAfter: running,
+        })
+      }
+    })
+  })
+
+  return result
+}
+
+const isMoveStep = (step: JourneyStep | undefined): step is JourneyMoveStep =>
+  step?.type === 'move'
+
+const isEpisodeStep = (
+  step: JourneyStep | undefined
+): step is JourneyEpisodeStep => step?.type === 'episode'
+
+const isQuestionStep = (
+  step: JourneyStep | undefined
+): step is JourneyQuestionStep => step?.type === 'question'
 
 export const JourneysScene = ({
   onAdvance,
@@ -89,44 +142,32 @@ export const JourneysScene = ({
 }: SceneComponentProps) => {
   const prefersReducedMotion = usePrefersReducedMotion()
 
-  const cumulativeDistances = useMemo(() => {
-    const totals = [0]
-    journeys.forEach((journey) => {
-      totals.push(totals[totals.length - 1] + journey.distanceKm)
+  const moveMetas = useMemo(() => buildMoveMetas(journeys), [journeys])
+  const moveMetaMap = useMemo(() => {
+    const map = new Map<string, MoveMeta>()
+    moveMetas.forEach((meta) => {
+      map.set(meta.stepId, meta)
     })
-    return totals
-  }, [journeys])
+    return map
+  }, [moveMetas])
 
-  const computeCompletedCount = useCallback(
-    (distance: number) => {
-      let count = 0
-      for (let i = 0; i < journeys.length; i += 1) {
-        const threshold = cumulativeDistances[i + 1] ?? Number.POSITIVE_INFINITY
-        if (distance >= threshold) {
-          count = i + 1
-        } else {
-          break
-        }
-      }
-      return count
-    },
-    [journeys.length, cumulativeDistances]
+  const responseMap = useMemo(() => {
+    const map = new Map<string, typeof responses[number]>()
+    responses.forEach((entry) => {
+      map.set(`${entry.journeyId}:${entry.stepId}`, entry)
+    })
+    return map
+  }, [responses])
+
+  const [activeJourneyIndex, setActiveJourneyIndex] = useState(0)
+  const [activeStepIndex, setActiveStepIndex] = useState(0)
+  const [animationState, setAnimationState] = useState<'idle' | 'animating' | 'complete'>(
+    'idle'
   )
-
-  const initialCompleted = computeCompletedCount(distanceTraveled)
-  const initialActiveIndex =
-    journeys.length === 0
-      ? 0
-      : Math.min(initialCompleted, journeys.length - 1)
-
-  const [completedCount, setCompletedCount] = useState(initialCompleted)
-  const [activeIndex, setActiveIndex] = useState(initialActiveIndex)
-  const [phase, setPhase] = useState<'idle' | 'animating' | 'arrived'>(
-    () => (initialCompleted > initialActiveIndex ? 'arrived' : 'idle')
-  )
-  const [animationToken, setAnimationToken] = useState(0)
-
   const animationTimeoutRef = useRef<number | null>(null)
+  const [animationToken, setAnimationToken] = useState(0)
+  const [draftAnswer, setDraftAnswer] = useState('')
+  const [editingStepKey, setEditingStepKey] = useState<string | null>(null)
 
   useEffect(
     () => () => {
@@ -138,213 +179,250 @@ export const JourneysScene = ({
   )
 
   useEffect(() => {
-    const derivedCompleted = computeCompletedCount(distanceTraveled)
-    if (derivedCompleted !== completedCount) {
-      setCompletedCount(derivedCompleted)
-    }
-  }, [distanceTraveled, computeCompletedCount, completedCount])
-
-  useEffect(() => {
     if (journeys.length === 0) {
-      setActiveIndex(0)
+      setActiveJourneyIndex(0)
+      setActiveStepIndex(0)
       return
     }
 
-    setActiveIndex((index) => Math.min(index, journeys.length - 1))
-  }, [journeys.length])
+    if (activeJourneyIndex >= journeys.length) {
+      setActiveJourneyIndex(journeys.length - 1)
+      setActiveStepIndex(0)
+    }
+  }, [activeJourneyIndex, journeys])
 
   useEffect(() => {
-    if (phase === 'animating') {
+    const journey = journeys[activeJourneyIndex]
+    if (!journey) {
+      setActiveStepIndex(0)
       return
     }
 
-    const hasArrived = activeIndex < completedCount
-    const nextPhase = hasArrived ? 'arrived' : 'idle'
-    if (nextPhase !== phase) {
-      setPhase(nextPhase)
+    if (activeStepIndex >= journey.steps.length) {
+      setActiveStepIndex(Math.max(journey.steps.length - 1, 0))
     }
-  }, [activeIndex, completedCount, phase])
+  }, [activeJourneyIndex, activeStepIndex, journeys])
 
-  const completedDistance =
-    cumulativeDistances[Math.min(completedCount, cumulativeDistances.length - 1)] ?? 0
+  const activeJourney = journeys[activeJourneyIndex]
+  const activeStep = activeJourney?.steps[activeStepIndex]
+
+  const stepKey = activeJourney && activeStep ? `${activeJourney.id}:${activeStep.id}` : ''
+  const storedResponse = stepKey ? responseMap.get(stepKey) : undefined
+  const isEditing = stepKey && editingStepKey === stepKey
 
   useEffect(() => {
-    setDistanceTraveled(completedDistance)
-  }, [completedDistance, setDistanceTraveled])
+    if (isQuestionStep(activeStep) && activeJourney) {
+      const key = `${activeJourney.id}:${activeStep.id}`
+      const stored = responseMap.get(key)
+      setDraftAnswer(stored?.answer ?? '')
+      setEditingStepKey(stored ? null : key)
+    } else {
+      setDraftAnswer('')
+      setEditingStepKey(null)
+    }
+  }, [activeJourney, activeStep, responseMap])
 
-  const currentJourney = journeys[activeIndex]
-  const currentJourneyKey = currentJourney ? getJourneyKey(currentJourney) : ''
-  const isCurrentCompleted = activeIndex < completedCount
+  useEffect(() => {
+    if (!isMoveStep(activeStep)) {
+      if (animationTimeoutRef.current !== null) {
+        window.clearTimeout(animationTimeoutRef.current)
+        animationTimeoutRef.current = null
+      }
+      setAnimationState('idle')
+      return
+    }
 
-  const currentDistance = currentJourney?.distanceKm ?? 0
-  const distanceBeforeCurrent =
-    cumulativeDistances[Math.min(activeIndex, cumulativeDistances.length - 1)] ?? 0
-  const distanceAfterCurrent =
-    cumulativeDistances[Math.min(activeIndex + 1, cumulativeDistances.length - 1)] ??
-    distanceBeforeCurrent + currentDistance
+    const meta = moveMetaMap.get(activeStep.id)
+    if (!meta) {
+      setAnimationState('idle')
+      return
+    }
+
+    if (distanceTraveled >= meta.cumulativeAfter - COMPLETION_EPSILON) {
+      setAnimationState('complete')
+    } else {
+      setAnimationState('idle')
+    }
+  }, [activeStep, distanceTraveled, moveMetaMap])
+
+  const completedDistance = Math.min(distanceTraveled, totalJourneyDistance)
+  const remainingDistance = Math.max(totalJourneyDistance - completedDistance, 0)
 
   const progressPercent = totalJourneyDistance
     ? Math.min(100, Math.max(0, (completedDistance / totalJourneyDistance) * 100))
     : 0
 
-  const activeJourneyResponses = useMemo(
-    () =>
-      responses.filter((entry) => entry.journeyKey === currentJourneyKey),
-    [responses, currentJourneyKey]
-  )
+  const moveMeta = isMoveStep(activeStep)
+    ? moveMetaMap.get(activeStep.id)
+    : undefined
 
-  const responseByPrompt = useMemo(() => {
-    const map = new Map<string, string>()
-    activeJourneyResponses.forEach((entry) => {
-      map.set(entry.prompt, entry.answer)
-    })
-    return map
-  }, [activeJourneyResponses])
+  const isMoveCompleted = moveMeta
+    ? completedDistance >= moveMeta.cumulativeAfter - COMPLETION_EPSILON
+    : false
 
-  const recordedAtByPrompt = useMemo(() => {
-    const map = new Map<string, string>()
-    activeJourneyResponses.forEach((entry) => {
-      map.set(entry.prompt, entry.recordedAt)
-    })
-    return map
-  }, [activeJourneyResponses])
+  const planeState: 'idle' | 'animating' | 'complete' = animationState
 
-  const [draftAnswers, setDraftAnswers] = useState<Record<string, string>>({})
-
-  useEffect(() => {
-    if (!currentJourney) {
-      setDraftAnswers({})
+  const handleStartMove = () => {
+    if (!isMoveStep(activeStep) || !activeJourney) {
       return
     }
 
-    const next: Record<string, string> = {}
-    currentJourney.prompts.forEach((prompt) => {
-      next[prompt.q] = responseByPrompt.get(prompt.q) ?? ''
-    })
-
-    setDraftAnswers(next)
-  }, [currentJourney, responseByPrompt])
-
-  const handleLaunch = () => {
-    if (!currentJourney || phase === 'animating') {
+    const meta = moveMetaMap.get(activeStep.id)
+    if (!meta) {
       return
     }
 
-    const duration = prefersReducedMotion ? 0 : PLANE_ANIMATION_MS
-    const isReplay = isCurrentCompleted
+    const finalize = () => {
+      setDistanceTraveled((current) => {
+        if (current >= meta.cumulativeAfter - COMPLETION_EPSILON) {
+          return current
+        }
+        return Math.min(meta.cumulativeAfter, totalJourneyDistance)
+      })
+      setAnimationState('complete')
+    }
 
+    if (
+      prefersReducedMotion ||
+      completedDistance >= meta.cumulativeAfter - COMPLETION_EPSILON
+    ) {
+      finalize()
+      return
+    }
+
+    setAnimationState('animating')
     setAnimationToken((token) => token + 1)
 
-    if (duration === 0) {
-      if (!isReplay) {
-        setCompletedCount((count) => Math.max(count, activeIndex + 1))
-      }
-      setPhase('arrived')
-      return
-    }
-
-    setPhase('animating')
     if (animationTimeoutRef.current !== null) {
       window.clearTimeout(animationTimeoutRef.current)
     }
 
     animationTimeoutRef.current = window.setTimeout(() => {
       animationTimeoutRef.current = null
-      if (!isReplay) {
-        setCompletedCount((count) => Math.max(count, activeIndex + 1))
-      }
-      setPhase('arrived')
-    }, duration)
+      finalize()
+    }, PLANE_ANIMATION_MS)
   }
 
-  const handlePrevJourney = () => {
-    if (activeIndex === 0) {
+  const handlePrevStep = () => {
+    if (!activeJourney) {
       return
     }
 
-    if (animationTimeoutRef.current !== null) {
-      window.clearTimeout(animationTimeoutRef.current)
-      animationTimeoutRef.current = null
-    }
-
-    setActiveIndex((index) => Math.max(index - 1, 0))
-  }
-
-  const handleNextJourney = () => {
-    if (!isCurrentCompleted) {
+    if (activeStepIndex > 0) {
+      setActiveStepIndex((index) => Math.max(index - 1, 0))
       return
     }
 
-    if (activeIndex === journeys.length - 1) {
+    if (activeJourneyIndex === 0) {
+      return
+    }
+
+    const nextJourneyIndex = activeJourneyIndex - 1
+    const nextJourney = journeys[nextJourneyIndex]
+    const nextStepIndex = Math.max((nextJourney?.steps.length ?? 1) - 1, 0)
+
+    setActiveJourneyIndex(nextJourneyIndex)
+    setActiveStepIndex(nextStepIndex)
+  }
+
+  const handleNextStep = () => {
+    if (!activeJourney) {
       onAdvance()
       return
     }
 
-    if (animationTimeoutRef.current !== null) {
-      window.clearTimeout(animationTimeoutRef.current)
-      animationTimeoutRef.current = null
-    }
-
-    setActiveIndex((index) => Math.min(index + 1, journeys.length - 1))
-  }
-
-  const handleAnswerChange = (prompt: string, value: string) => {
-    if (!currentJourney || !isCurrentCompleted) {
+    if (activeStepIndex < activeJourney.steps.length - 1) {
+      setActiveStepIndex((index) => index + 1)
       return
     }
 
-    setDraftAnswers((prev) => ({ ...prev, [prompt]: value }))
-    saveResponse({
-      journeyKey: currentJourneyKey,
-      prompt,
-      answer: value,
-    })
+    if (activeJourneyIndex >= journeys.length - 1) {
+      onAdvance()
+      return
+    }
+
+    const nextJourneyIndex = activeJourneyIndex + 1
+    setActiveJourneyIndex(nextJourneyIndex)
+    setActiveStepIndex(0)
   }
 
-  if (!currentJourney) {
+  const handleToggleEditing = () => {
+    if (!isQuestionStep(activeStep) || !activeJourney || !stepKey) {
+      return
+    }
+
+    setEditingStepKey((current) => (current === stepKey ? null : stepKey))
+  }
+
+  const handleAnswerChange = useCallback(
+    (value: string) => {
+      if (!isQuestionStep(activeStep) || !activeJourney) {
+        return
+      }
+
+      const key = `${activeJourney.id}:${activeStep.id}`
+      if (storedResponse && editingStepKey !== key) {
+        return
+      }
+
+      setDraftAnswer(value)
+      saveResponse({
+        journeyId: activeJourney.id,
+        stepId: activeStep.id,
+        prompt: activeStep.prompt,
+        answer: value,
+      })
+    },
+    [activeJourney, activeStep, editingStepKey, saveResponse, storedResponse]
+  )
+
+  if (!activeJourney || !activeStep) {
     return (
       <SceneLayout
         eyebrow="Journeys"
         title="移動演出と思い出ギャラリー"
-        description="東京⇄福岡の移動をSVGアニメで描写しつつ、写真とキャプション、質問入力を組み合わせるハブシーンです。"
+        description="旅データを整備すると、ここに移動アニメーションと質問カードが並びます。"
       >
         <p className="scene-note">
-          まだ旅のデータが登録されていません。JSONを整備したら、ここに移動演出と質問カードが並びます。
+          まだ旅のデータが登録されていません。`src/data/journeys.ts` にステップを追加してください。
         </p>
       </SceneLayout>
     )
   }
 
-  const transport = transportMeta[currentJourney.transport]
-  const planeState: 'idle' | 'animating' | 'complete' =
-    phase === 'animating'
-      ? 'animating'
-      : isCurrentCompleted
-        ? 'complete'
-        : 'idle'
-
-  const progressState: 'idle' | 'animating' | 'complete' = planeState
-
-  const remainingDistance = Math.max(totalJourneyDistance - completedDistance, 0)
+  const transport = isMoveStep(activeStep)
+    ? transportMeta[activeStep.transport]
+    : undefined
 
   const statusLabel = (() => {
-    if (phase === 'animating') {
+    if (!isMoveStep(activeStep)) {
+      return ''
+    }
+
+    if (animationState === 'animating') {
       return '移動中…'
     }
-    if (isCurrentCompleted) {
+
+    if (isMoveCompleted) {
       return '到着済み — 記録を残そう'
     }
-    return `${currentJourney.from} → ${currentJourney.to} を開始 (タップ)`
+
+    return `${activeStep.from} → ${activeStep.to} を開始 (タップ)`
   })()
 
-  const planeClassName = [
-    'journey-map__plane',
-    prefersReducedMotion && planeState === 'complete'
-      ? 'journey-map__plane--static'
-      : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
+  const isFinalJourney =
+    activeJourneyIndex === journeys.length - 1 && journeys.length > 0
+  const isFinalStep =
+    isFinalJourney && activeStepIndex === activeJourney.steps.length - 1
+
+  const nextButtonLabel = isFinalStep
+    ? 'Messagesへ進む'
+    : activeStepIndex === activeJourney.steps.length - 1
+      ? '次の旅へ'
+      : '次のステップ'
+
+  const prevDisabled = activeJourneyIndex === 0 && activeStepIndex === 0
+  const nextDisabled = isMoveStep(activeStep) && !isMoveCompleted
 
   return (
     <SceneLayout
@@ -356,185 +434,281 @@ export const JourneysScene = ({
         <header className="journeys-header">
           <div className="journeys-header__row">
             <span className="journeys-header__label">
-              JOURNEY {activeIndex + 1}/{journeys.length}
+              JOURNEY {activeJourneyIndex + 1}/{journeys.length}
             </span>
             <span className="journeys-header__distance">
               累計 {formatDistance(completedDistance)} km
             </span>
           </div>
+          <h2 className="journeys-header__title">{activeJourney.title}</h2>
+          <p className="journeys-header__step">
+            STEP {activeStepIndex + 1}/{activeJourney.steps.length} ·{' '}
+            {stepTypeLabel[activeStep.type]}
+          </p>
           <div className="journeys-progress-bar" aria-hidden="true">
             <div
               className="journeys-progress-bar__fill"
               style={{ width: `${progressPercent}%` }}
             />
           </div>
+          <div className="journeys-step-indicator" aria-hidden="true">
+            {activeJourney.steps.map((step, index) => {
+              const className = [
+                'journeys-step-indicator__dot',
+                index === activeStepIndex
+                  ? 'is-current'
+                  : index < activeStepIndex
+                    ? 'is-complete'
+                    : '',
+              ]
+                .filter(Boolean)
+                .join(' ')
+
+              return <span key={step.id} className={className} />
+            })}
+          </div>
           <div className="journeys-header__secondary">
+            <span>残り {formatDistance(remainingDistance)} km</span>
             <span>
-              残り {formatDistance(remainingDistance)} km
-            </span>
-            <span>
-              {isCurrentCompleted
-                ? `到着済み: ${formatDistance(distanceAfterCurrent)} km`
-                : `出発前: ${formatDistance(distanceBeforeCurrent)} km`}
+              {isMoveCompleted
+                ? `到着済み: ${formatDistance(
+                    moveMeta?.cumulativeAfter ?? completedDistance
+                  )} km`
+                : `出発前: ${formatDistance(
+                    moveMeta?.cumulativeBefore ?? completedDistance
+                  )} km`}
             </span>
           </div>
         </header>
 
-        <button
-          type="button"
-          className="journey-map"
-          onClick={handleLaunch}
-          disabled={phase === 'animating'}
-          aria-live="polite"
-          aria-label={`${currentJourney.from}から${currentJourney.to}への移動を開始`}
-        >
-          <span className="journey-map__glow" aria-hidden="true" />
-          <div className="journey-map__line" aria-hidden="true">
-            <span className="journey-map__line-track" />
-            <span
-              key={`progress-${activeIndex}-${animationToken}-${progressState}`}
-              className="journey-map__line-progress"
-              data-state={progressState}
-            />
-          </div>
-          <span
-            key={`plane-${activeIndex}-${animationToken}-${planeState}`}
-            className={planeClassName}
-            data-state={planeState}
-            aria-hidden="true"
-          >
-            <svg viewBox="0 0 60 32" role="img" aria-hidden="true">
-              <path
-                d="M2 14h24l8-10h7l-7 10h18l4 2-4 2H34l7 10h-7l-8-10H2l-2-2z"
-                fill="url(#planeGradient)"
-              />
-              <defs>
-                <linearGradient id="planeGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                  <stop offset="0%" stopColor="#ff66c4" />
-                  <stop offset="100%" stopColor="#4d7bff" />
-                </linearGradient>
-              </defs>
-            </svg>
-          </span>
-          <div className="journey-map__labels" aria-hidden="true">
-            <span>{currentJourney.from}</span>
-            <span>{currentJourney.to}</span>
-          </div>
-          <span className="journey-map__status">{statusLabel}</span>
-        </button>
-
-        <div className="journey-card">
-          <div
-            className="journey-card__media"
-            style={{ background: getArtBackground(currentJourney.artKey) }}
-          >
-            <img
-              className="journey-card__photo"
-              src={currentJourney.photoURL}
-              alt={`${currentJourney.from}から${currentJourney.to}の思い出写真`}
-              loading="lazy"
-            />
-            <span className="journey-card__badge">
-              <span className="journey-card__badge-icon" aria-hidden="true">
-                {transport.icon}
-              </span>
-              {transport.label}
-            </span>
-          </div>
-          <div className="journey-card__body">
-            <div className="journey-card__meta">
-              <span
-                className={`journey-status journey-status--${
-                  isCurrentCompleted ? 'arrived' : 'pending'
-                }`}
+        <div className="journeys-stage">
+          {isMoveStep(activeStep) ? (
+            <>
+              <button
+                type="button"
+                className="journey-map"
+                onClick={handleStartMove}
+                disabled={animationState === 'animating'}
+                aria-live="polite"
+                aria-label={`${activeStep.from}から${activeStep.to}への移動を開始`}
+                style={{ background: getArtBackground(activeStep.artKey) }}
               >
-                {isCurrentCompleted ? 'ARRIVED' : 'READY'}
-              </span>
-              <span className="journey-card__date">
-                {formatJourneyDate(currentJourney.date)}
-              </span>
-            </div>
-            <div className="journey-card__route">
-              <span className="journey-card__city">{currentJourney.from}</span>
-              <span className="journey-card__arrow" aria-hidden="true">
-                →
-              </span>
-              <span className="journey-card__city">{currentJourney.to}</span>
-            </div>
-            <div className="journey-card__transport">
-              <span>{transport.icon}</span>
-              <span>{transport.label}</span>
-              <span>{formatDistance(currentJourney.distanceKm)} km</span>
-            </div>
-            <p className="journey-card__caption">{currentJourney.caption}</p>
-            <div className="journey-card__stats">
-              <div>
-                <p className="journey-card__stat-label">今回の移動距離</p>
-                <p className="journey-card__stat-value">
-                  {formatDistance(currentJourney.distanceKm)} km
-                </p>
-              </div>
-              <div>
-                <p className="journey-card__stat-label">累計距離</p>
-                <p className="journey-card__stat-value">
-                  {formatDistance(
-                    isCurrentCompleted ? distanceAfterCurrent : distanceBeforeCurrent
-                  )}{' '}
-                  km
-                </p>
-              </div>
-            </div>
-            <div className="journey-prompts">
-              {!isCurrentCompleted ? (
-                <p className="journey-prompts__locked">
-                  フライトを完了すると質問が開きます。
-                </p>
-              ) : null}
-              {currentJourney.prompts.map((prompt) => {
-                const answer = draftAnswers[prompt.q] ?? ''
-                const recordedAt = recordedAtByPrompt.get(prompt.q)
+                <span className="journey-map__glow" aria-hidden="true" />
+                <div className="journey-map__line" aria-hidden="true">
+                  <span className="journey-map__line-track" />
+                  <span
+                    key={`progress-${activeStep.id}-${animationToken}-${planeState}`}
+                    className="journey-map__line-progress"
+                    data-state={planeState}
+                  />
+                </div>
+                <span
+                  key={`plane-${activeStep.id}-${animationToken}-${planeState}`}
+                  className={`journey-map__plane${
+                    prefersReducedMotion && planeState === 'complete'
+                      ? ' journey-map__plane--static'
+                      : ''
+                  }`}
+                  data-state={planeState}
+                  aria-hidden="true"
+                >
+                  <svg viewBox="0 0 60 32" role="img" aria-hidden="true">
+                    <path
+                      d="M2 14h24l8-10h7l-7 10h18l4 2-4 2H34l7 10h-7l-8-10H2l-2-2z"
+                      fill="url(#planeGradient)"
+                    />
+                    <defs>
+                      <linearGradient
+                        id="planeGradient"
+                        x1="0%"
+                        y1="0%"
+                        x2="100%"
+                        y2="100%"
+                      >
+                        <stop offset="0%" stopColor="#ff66c4" />
+                        <stop offset="100%" stopColor="#4d7bff" />
+                      </linearGradient>
+                    </defs>
+                  </svg>
+                </span>
+                <div className="journey-map__labels" aria-hidden="true">
+                  <span>{activeStep.from}</span>
+                  <span>{activeStep.to}</span>
+                </div>
+                <span className="journey-map__status">{statusLabel}</span>
+              </button>
 
-                return (
-                  <label className="journey-prompt" key={prompt.q}>
-                    <span className="journey-prompt__question">{prompt.q}</span>
+              <article className="journey-card journey-card--move">
+                <div className="journey-card__body">
+                  <div className="journey-card__meta">
+                    <span
+                      className={`journey-status journey-status--${
+                        isMoveCompleted ? 'arrived' : 'pending'
+                      }`}
+                    >
+                      {isMoveCompleted ? 'ARRIVED' : 'READY'}
+                    </span>
+                    <span className="journey-card__date">
+                      {formatJourneyDate(activeJourney.date)}
+                    </span>
+                  </div>
+                  <div className="journey-card__route">
+                    <span className="journey-card__city">{activeStep.from}</span>
+                    <span className="journey-card__arrow" aria-hidden="true">
+                      →
+                    </span>
+                    <span className="journey-card__city">{activeStep.to}</span>
+                  </div>
+                  <div className="journey-card__transport">
+                    <span aria-hidden="true">{transport?.icon}</span>
+                    <span>{transport?.label}</span>
+                    <span>{formatDistance(activeStep.distanceKm)} km</span>
+                  </div>
+                  <p className="journey-card__caption">
+                    {activeStep.description ?? activeJourney.title}
+                  </p>
+                  <div className="journey-card__stats">
+                    <div>
+                      <p className="journey-card__stat-label">今回の移動距離</p>
+                      <p className="journey-card__stat-value">
+                        {formatDistance(activeStep.distanceKm)} km
+                      </p>
+                    </div>
+                    <div>
+                      <p className="journey-card__stat-label">
+                        {isMoveCompleted
+                          ? '累計距離 (到着済み)'
+                          : '累計距離 (出発前)'}
+                      </p>
+                      <p className="journey-card__stat-value">
+                        {formatDistance(
+                          isMoveCompleted
+                            ? moveMeta?.cumulativeAfter ?? completedDistance
+                            : moveMeta?.cumulativeBefore ?? completedDistance
+                        )}{' '}
+                        km
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </article>
+            </>
+          ) : null}
+
+          {isEpisodeStep(activeStep) ? (
+            <article className="journey-card journey-card--episode">
+              <div
+                className="journey-card__media"
+                style={{ background: getArtBackground(activeStep.artKey) }}
+              >
+                <img
+                  className="journey-card__photo"
+                  src={activeStep.media.src}
+                  alt={activeStep.media.alt}
+                  loading="lazy"
+                  style={
+                    activeStep.media.objectPosition
+                      ? { objectPosition: activeStep.media.objectPosition }
+                      : undefined
+                  }
+                />
+                <span className="journey-card__badge">
+                  <span className="journey-card__badge-icon" aria-hidden="true">
+                    ✨
+                  </span>
+                  MEMORIES
+                </span>
+              </div>
+              <div className="journey-card__body">
+                <div className="journey-card__meta">
+                  <span className="journey-status journey-status--arrived">
+                    EPISODE
+                  </span>
+                  <span className="journey-card__date">
+                    {formatJourneyDate(activeJourney.date)}
+                  </span>
+                </div>
+                <h3 className="journey-card__episode-title">{activeStep.title}</h3>
+                <p className="journey-card__caption">{activeStep.caption}</p>
+              </div>
+            </article>
+          ) : null}
+
+          {isQuestionStep(activeStep) ? (
+            <article className="journey-card journey-card--question">
+              <div className="journey-card__body">
+                <div className="journey-card__meta">
+                  <span className="journey-status journey-status--arrived">
+                    RECORD
+                  </span>
+                  <span className="journey-card__date">
+                    {formatJourneyDate(activeJourney.date)}
+                  </span>
+                </div>
+                <div className="journey-prompts journey-prompts--single">
+                  <label className="journey-prompt" htmlFor={activeStep.id}>
+                    <span className="journey-prompt__question">
+                      {activeStep.prompt}
+                    </span>
+                    {activeStep.helper ? (
+                      <span className="journey-prompt__helper">
+                        {activeStep.helper}
+                      </span>
+                    ) : null}
                     <textarea
+                      id={activeStep.id}
                       className="journey-prompt__input"
-                      value={answer}
-                      placeholder="ここに感じたことをメモ"
-                      onChange={(event) =>
-                        handleAnswerChange(prompt.q, event.currentTarget.value)
+                      value={draftAnswer}
+                      placeholder={
+                        activeStep.placeholder ?? 'ここに感じたことをメモ'
                       }
-                      disabled={!isCurrentCompleted}
+                      onChange={(event) =>
+                        handleAnswerChange(event.currentTarget.value)
+                      }
+                      disabled={Boolean(storedResponse && !isEditing)}
                       rows={3}
                     />
-                    <span className="journey-prompt__status">
-                      {recordedAt
-                        ? `記録: ${formatRecordedAt(recordedAt)}`
-                        : '未記録'}
-                    </span>
+                    <div className="journey-prompt__footer">
+                      <span className="journey-prompt__status">
+                        {storedResponse?.recordedAt
+                          ? `記録: ${formatRecordedAt(
+                              storedResponse.recordedAt
+                            )}`
+                          : '未記録'}
+                      </span>
+                      {storedResponse ? (
+                        <button
+                          type="button"
+                          className="journey-prompt__toggle"
+                          onClick={handleToggleEditing}
+                        >
+                          {isEditing ? '閲覧モードに戻す' : '編集する'}
+                        </button>
+                      ) : null}
+                    </div>
                   </label>
-                )
-              })}
-            </div>
-          </div>
+                </div>
+              </div>
+            </article>
+          ) : null}
         </div>
 
         <nav className="journeys-nav" aria-label="Journeys navigation">
           <button
             type="button"
             className="journeys-nav__button"
-            onClick={handlePrevJourney}
-            disabled={activeIndex === 0}
+            onClick={handlePrevStep}
+            disabled={prevDisabled}
           >
-            前の旅へ
+            前のステップ
           </button>
           <button
             type="button"
             className="journeys-nav__button journeys-nav__button--primary"
-            onClick={handleNextJourney}
-            disabled={!isCurrentCompleted}
+            onClick={handleNextStep}
+            disabled={nextDisabled}
           >
-            {activeIndex === journeys.length - 1 ? 'Messagesへ進む' : '次の移動へ'}
+            {nextButtonLabel}
           </button>
         </nav>
       </div>

--- a/src/scenes/MeetupsScene.tsx
+++ b/src/scenes/MeetupsScene.tsx
@@ -1,20 +1,122 @@
+import { useState } from 'react'
+import type { CSSProperties } from 'react'
+
 import { SceneLayout } from '../components/SceneLayout'
+import { meetupPages } from '../data/meetups'
 import type { SceneComponentProps } from '../types/scenes'
 
 export const MeetupsScene = ({ onAdvance }: SceneComponentProps) => {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const activePage = meetupPages[activeIndex]
+
+  const handlePrev = () => {
+    setActiveIndex((index) => Math.max(index - 1, 0))
+  }
+
+  const handleNext = () => {
+    if (activeIndex >= meetupPages.length - 1) {
+      onAdvance()
+      return
+    }
+
+    setActiveIndex((index) => Math.min(index + 1, meetupPages.length - 1))
+  }
+
+  const handleSelect = (index: number) => {
+    setActiveIndex(index)
+  }
+
+  const isFirst = activeIndex === 0
+  const isLast = activeIndex === meetupPages.length - 1
+
   return (
     <SceneLayout
       eyebrow="Meetups"
       title="月ごとのアルバム"
       description="月替わりのメディアアート背景に写真と手書きメモを載せる、展示会のようなギャラリーセクション。"
-      onAdvance={onAdvance}
-      advanceLabel="Letterへ"
     >
-      <ul className="scene-list">
-        <li>縦横比の異なるiPhone写真に対応するレイアウトを検討中。</li>
-        <li>スワイプ風のトランジションで月を切り替え、没入感を演出。</li>
-        <li>ここでも自由回答を差し込める余白を用意します。</li>
-      </ul>
+      <div className="meetups-gallery">
+        <section
+          className="meetups-art"
+          style={{
+            background: activePage.background,
+            '--meetups-accent': activePage.accent,
+            '--meetups-ambient': activePage.ambient,
+          } as CSSProperties}
+        >
+          <div className="meetups-art__glow" aria-hidden="true" />
+          <img
+            className="meetups-art__photo"
+            src={activePage.photo.src}
+            alt={activePage.photo.alt}
+            loading="lazy"
+            style={
+              activePage.photo.objectPosition
+                ? { objectPosition: activePage.photo.objectPosition }
+                : undefined
+            }
+          />
+          <header className="meetups-art__header">
+            <span className="meetups-art__month">{activePage.monthLabel}</span>
+            <h3 className="meetups-art__title">{activePage.title}</h3>
+            <p className="meetups-art__subtitle">{activePage.subtitle}</p>
+          </header>
+        </section>
+
+        <section className="meetups-notes">
+          <p className="meetups-notes__description">{activePage.description}</p>
+          <ul className="meetups-notes__list">
+            {activePage.memoryPoints.map((point) => (
+              <li key={point}>{point}</li>
+            ))}
+          </ul>
+          {activePage.footnote ? (
+            <p className="meetups-notes__footnote">{activePage.footnote}</p>
+          ) : null}
+        </section>
+
+        <div className="meetups-controls">
+          <button
+            type="button"
+            className="meetups-controls__button"
+            onClick={handlePrev}
+            disabled={isFirst}
+          >
+            前のページ
+          </button>
+          <button
+            type="button"
+            className="meetups-controls__button meetups-controls__button--primary"
+            onClick={handleNext}
+          >
+            {isLast ? 'Letterへ' : '次のページ'}
+          </button>
+        </div>
+
+        <nav className="meetups-timeline" aria-label="Meetups timeline">
+          {meetupPages.map((page, index) => {
+            const className = [
+              'meetups-timeline__item',
+              index === activeIndex ? 'is-active' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')
+
+            return (
+              <button
+                key={page.id}
+                type="button"
+                className={className}
+                onClick={() => handleSelect(index)}
+                aria-current={index === activeIndex}
+              >
+                <span className="meetups-timeline__month">{page.monthLabel}</span>
+                <span className="meetups-timeline__label">{page.title}</span>
+              </button>
+            )
+          })}
+        </nav>
+      </div>
     </SceneLayout>
   )
 }

--- a/src/types/experience.ts
+++ b/src/types/experience.ts
@@ -1,5 +1,6 @@
 export interface SaveJourneyResponsePayload {
-  journeyKey: string
+  journeyId: string
+  stepId: string
   prompt: string
   answer: string
 }

--- a/src/types/journey.ts
+++ b/src/types/journey.ts
@@ -1,18 +1,50 @@
 export type TransportMode = 'plane' | 'bus' | 'train'
 
-export interface JourneyPrompt {
-  q: string
-  answer?: string
-}
-
-export interface Journey {
-  date: string
+export interface JourneyMoveStep {
+  id: string
+  type: 'move'
   from: string
   to: string
   transport: TransportMode
-  caption: string
-  photoURL: string
-  artKey: string
+  /** 距離HUDに反映する移動距離（km）。 */
   distanceKm: number
-  prompts: JourneyPrompt[]
+  /** メディアアート背景のキー。 */
+  artKey: string
+  /** ステップ固有のラベルや補足文。 */
+  description?: string
+}
+
+export interface JourneyEpisodeStep {
+  id: string
+  type: 'episode'
+  title: string
+  caption: string
+  artKey: string
+  media: {
+    src: string
+    alt: string
+    objectPosition?: string
+  }
+}
+
+export interface JourneyQuestionStep {
+  id: string
+  type: 'question'
+  prompt: string
+  placeholder?: string
+  helper?: string
+}
+
+export type JourneyStep =
+  | JourneyMoveStep
+  | JourneyEpisodeStep
+  | JourneyQuestionStep
+
+export interface Journey {
+  id: string
+  title: string
+  date: string
+  /** 旅全体の距離（moveステップの合計）。 */
+  distanceKm: number
+  steps: JourneyStep[]
 }

--- a/src/types/scenes.ts
+++ b/src/types/scenes.ts
@@ -1,3 +1,5 @@
+import type { Dispatch, SetStateAction } from 'react'
+
 import type { Journey } from './journey'
 import type {
   JourneyPromptResponse,
@@ -20,15 +22,15 @@ export interface SceneComponentProps {
   onRestart: () => void
   journeys: Journey[]
   /**
-   * Sum of the journey distances that have been experienced so far.
-   * Displayed in the persistent HUD and reused by later scenes (quizzes/result).
+   * moveステップの移動距離を積算した合計値。
+   * 距離HUDおよびMessages/Resultで利用する。
    */
   distanceTraveled: number
   /** Total distance if every journey in the dataset is completed. */
   totalJourneyDistance: number
   responses: JourneyPromptResponse[]
   saveResponse: (payload: SaveJourneyResponsePayload) => void
-  setDistanceTraveled: (value: number) => void
+  setDistanceTraveled: Dispatch<SetStateAction<number>>
 }
 
 export const sceneOrder: SceneId[] = [


### PR DESCRIPTION
## Summary
- refactor journeys data into move/episode/question steps and update the scene to drive distance HUD, animation, and local-storage-backed answer toggles
- add meetups data with per-month media art plus an interactive gallery scene and supporting styles
- refresh shared docs and styles: expand README with conflict guide/E2E checklist and update CSS for journeys and meetups

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce6f0537fc832fbdeffbd4009e2d99