### PR TITLE
Refine journeys flow for scrollable paper-theater memories

### DIFF
--- a/public/images/journey-travel-001-airport.svg
+++ b/public/images/journey-travel-001-airport.svg
@@ -1,0 +1,32 @@
+<svg width="640" height="900" viewBox="0 0 640 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Travel 001 Airport Reunion</title>
+  <desc id="desc">A stylised illustration placeholder showing two people meeting at an airport lobby.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#211f6b" />
+      <stop offset="100%" stop-color="#402c7a" />
+    </linearGradient>
+    <radialGradient id="light" cx="0.3" cy="0.28" r="0.6">
+      <stop offset="0%" stop-color="rgba(255, 170, 220, 0.65)" />
+      <stop offset="100%" stop-color="rgba(33, 31, 107, 0)" />
+    </radialGradient>
+  </defs>
+  <rect width="640" height="900" fill="url(#bg)" />
+  <rect width="640" height="900" fill="url(#light)" />
+  <g fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="1.5">
+    <path d="M80 760 L560 760" />
+    <path d="M80 780 L560 780" />
+    <path d="M140 220 Q320 140 500 220" />
+    <path d="M140 260 Q320 180 500 260" />
+  </g>
+  <g fill="#f4edff" font-family="'Noto Sans JP', 'Segoe UI', sans-serif" text-anchor="middle">
+    <text x="320" y="430" font-size="38" font-weight="600">AIRPORT LOBBY</text>
+    <text x="320" y="480" font-size="22" opacity="0.78">First Meeting in Fukuoka</text>
+    <text x="320" y="525" font-size="20" opacity="0.6">2024.10</text>
+  </g>
+  <g fill="rgba(255,255,255,0.22)">
+    <circle cx="200" cy="600" r="46" />
+    <circle cx="440" cy="600" r="46" />
+    <path d="M200 646 L320 680 L440 646" />
+  </g>
+</svg>

--- a/public/images/journey-travel-001-night.svg
+++ b/public/images/journey-travel-001-night.svg
@@ -1,0 +1,36 @@
+<svg width="640" height="900" viewBox="0 0 640 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Travel 001 Night View</title>
+  <desc id="desc">A stylised illustration placeholder of a hotel night view.</desc>
+  <defs>
+    <linearGradient id="night" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#120b36" />
+      <stop offset="100%" stop-color="#2b164d" />
+    </linearGradient>
+    <linearGradient id="window" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff80c0" stop-opacity="0.8" />
+      <stop offset="100%" stop-color="#7ab1ff" stop-opacity="0.8" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="900" fill="url(#night)" />
+  <g opacity="0.22" stroke="#fff" stroke-width="1">
+    <path d="M80 720 L560 720" />
+    <path d="M80 750 L560 750" />
+    <path d="M110 780 L530 780" />
+  </g>
+  <g>
+    <rect x="160" y="180" width="320" height="420" rx="28" fill="rgba(255,255,255,0.06)" />
+    <rect x="190" y="210" width="260" height="360" rx="18" fill="rgba(255,255,255,0.08)" />
+    <rect x="210" y="230" width="220" height="320" rx="12" fill="url(#window)" opacity="0.9" />
+  </g>
+  <g fill="#f4edff" font-family="'Noto Sans JP', 'Segoe UI', sans-serif" text-anchor="middle">
+    <text x="320" y="630" font-size="36" font-weight="600">HOTEL NIGHT</text>
+    <text x="320" y="676" font-size="22" opacity="0.75">Whispered plans before sleeping</text>
+  </g>
+  <g fill="rgba(255,255,255,0.4)">
+    <circle cx="200" cy="820" r="8" />
+    <circle cx="260" cy="790" r="6" />
+    <circle cx="340" cy="812" r="7" />
+    <circle cx="420" cy="784" r="5" />
+    <circle cx="480" cy="816" r="9" />
+  </g>
+</svg>

--- a/public/images/journey-travel-002-deck.svg
+++ b/public/images/journey-travel-002-deck.svg
@@ -1,0 +1,39 @@
+<svg width="640" height="900" viewBox="0 0 640 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Travel 002 Observation Deck</title>
+  <desc id="desc">A stylised illustration placeholder of an observation deck overlooking Tokyo.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#37164c" />
+      <stop offset="100%" stop-color="#111638" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.75" cy="0.2" r="0.5">
+      <stop offset="0%" stop-color="rgba(255, 102, 196, 0.6)" />
+      <stop offset="100%" stop-color="rgba(17, 22, 56, 0)" />
+    </radialGradient>
+  </defs>
+  <rect width="640" height="900" fill="url(#sky)" />
+  <rect width="640" height="900" fill="url(#glow)" />
+  <g stroke="rgba(255,255,255,0.25)" stroke-width="1.2" fill="none">
+    <path d="M120 680 L520 680" />
+    <path d="M120 710 L520 710" />
+    <path d="M200 360 L200 710" />
+    <path d="M440 360 L440 710" />
+  </g>
+  <g fill="rgba(255,255,255,0.14)">
+    <rect x="160" y="420" width="80" height="190" rx="18" />
+    <rect x="280" y="360" width="90" height="250" rx="22" />
+    <rect x="410" y="400" width="70" height="210" rx="18" />
+  </g>
+  <g fill="#f4edff" font-family="'Noto Sans JP', 'Segoe UI', sans-serif" text-anchor="middle">
+    <text x="320" y="620" font-size="34" font-weight="600">OBSERVATION DECK</text>
+    <text x="320" y="662" font-size="22" opacity="0.75">Tokyo Night Pulse</text>
+    <text x="320" y="702" font-size="20" opacity="0.6">Secret Valentine Mission</text>
+  </g>
+  <g fill="#ffceeb" opacity="0.8">
+    <circle cx="160" cy="260" r="6" />
+    <circle cx="220" cy="220" r="4" />
+    <circle cx="320" cy="200" r="8" />
+    <circle cx="420" cy="240" r="5" />
+    <circle cx="480" cy="210" r="7" />
+  </g>
+</svg>

--- a/public/images/journey-travel-003-festival.svg
+++ b/public/images/journey-travel-003-festival.svg
@@ -1,0 +1,35 @@
+<svg width="640" height="900" viewBox="0 0 640 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Travel 003 Summer Festival</title>
+  <desc id="desc">A stylised illustration placeholder of a summer festival under meteor shower.</desc>
+  <defs>
+    <linearGradient id="night2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f1e3a" />
+      <stop offset="100%" stop-color="#1b0f34" />
+    </linearGradient>
+    <radialGradient id="meteor" cx="0.5" cy="0.2" r="0.6">
+      <stop offset="0%" stop-color="rgba(120, 225, 255, 0.6)" />
+      <stop offset="100%" stop-color="rgba(15, 30, 58, 0)" />
+    </radialGradient>
+  </defs>
+  <rect width="640" height="900" fill="url(#night2)" />
+  <rect width="640" height="900" fill="url(#meteor)" />
+  <g stroke="rgba(255,255,255,0.35)" stroke-width="2" stroke-linecap="round">
+    <line x1="120" y1="220" x2="220" y2="280" />
+    <line x1="300" y1="180" x2="420" y2="260" />
+    <line x1="460" y1="200" x2="560" y2="260" />
+  </g>
+  <g fill="rgba(255, 196, 0, 0.6)">
+    <circle cx="180" cy="420" r="50" />
+    <circle cx="320" cy="460" r="58" />
+    <circle cx="460" cy="420" r="44" />
+  </g>
+  <g fill="#f4edff" font-family="'Noto Sans JP', 'Segoe UI', sans-serif" text-anchor="middle">
+    <text x="320" y="640" font-size="36" font-weight="600">SUMMER FESTIVAL</text>
+    <text x="320" y="684" font-size="22" opacity="0.75">Fireworks &amp; Meteors</text>
+    <text x="320" y="724" font-size="20" opacity="0.6">Shared Wishes</text>
+  </g>
+  <g fill="rgba(255,255,255,0.2)">
+    <path d="M140 780 C200 720, 440 720, 500 780" />
+    <path d="M160 810 C230 750, 410 750, 480 810" />
+  </g>
+</svg>

--- a/public/images/journey-travel-003-letter.svg
+++ b/public/images/journey-travel-003-letter.svg
@@ -1,0 +1,35 @@
+<svg width="640" height="900" viewBox="0 0 640 900" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Travel 003 Letter Exchange</title>
+  <desc id="desc">A stylised illustration placeholder of a letter exchange by the riverside.</desc>
+  <defs>
+    <linearGradient id="evening" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#10142c" />
+      <stop offset="100%" stop-color="#241042" />
+    </linearGradient>
+    <linearGradient id="letter" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffe3a8" />
+      <stop offset="100%" stop-color="#ffc0d7" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="900" fill="url(#evening)" />
+  <g fill="rgba(255,255,255,0.2)">
+    <circle cx="160" cy="200" r="6" />
+    <circle cx="220" cy="180" r="5" />
+    <circle cx="320" cy="160" r="7" />
+    <circle cx="420" cy="190" r="4" />
+    <circle cx="500" cy="170" r="6" />
+  </g>
+  <g>
+    <path d="M100 720 Q320 640 540 720" fill="none" stroke="rgba(255,255,255,0.18)" stroke-width="3" />
+    <path d="M80 760 Q320 680 560 760" fill="none" stroke="rgba(255,255,255,0.12)" stroke-width="3" />
+  </g>
+  <g>
+    <rect x="220" y="360" width="200" height="150" rx="20" fill="url(#letter)" />
+    <path d="M220 360 L320 440 L420 360" fill="rgba(255,140,200,0.45)" />
+    <path d="M220 510 L320 430 L420 510" fill="rgba(255,105,180,0.38)" />
+  </g>
+  <g fill="#f4edff" font-family="'Noto Sans JP', 'Segoe UI', sans-serif" text-anchor="middle">
+    <text x="320" y="620" font-size="34" font-weight="600">LETTER IN THE NIGHT</text>
+    <text x="320" y="662" font-size="22" opacity="0.75">Promises under river breeze</text>
+  </g>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -95,6 +95,9 @@
   flex: 1;
   display: flex;
   padding: calc(env(safe-area-inset-top, 0px) + 1.75rem) 1.5rem calc(env(safe-area-inset-bottom, 0px) + 2.25rem);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  min-height: 0;
 }
 
 .scene-footer {
@@ -797,6 +800,38 @@
   color: rgba(245, 244, 255, 0.7);
 }
 
+.journeys-header__meta {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  color: rgba(245, 244, 255, 0.72);
+}
+
+.journeys-header__date {
+  font-weight: 500;
+}
+
+.journeys-header__mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(163, 174, 255, 0.28);
+  background: rgba(12, 16, 48, 0.55);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.82);
+}
+
+.journeys-header__mode span:first-child {
+  font-size: 1rem;
+}
+
 .journeys-progress-bar {
   position: relative;
   height: 6px;
@@ -931,10 +966,65 @@
   transform: scaleX(1);
 }
 
+.journey-map--route .journey-map__line {
+  display: none;
+}
+
+.journey-map__route-visual {
+  position: relative;
+  height: 76px;
+}
+
+.journey-map__route-visual svg {
+  width: 100%;
+  height: 100%;
+}
+
+.journey-map__route-track {
+  fill: none;
+  stroke: rgba(163, 174, 255, 0.35);
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.journey-map__route-progress {
+  fill: none;
+  stroke: rgba(255, 102, 196, 0.95);
+  stroke-width: 2.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-dasharray: 400;
+  stroke-dashoffset: 400;
+  opacity: 0;
+  transition: stroke-dashoffset 1.45s cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 0.3s ease;
+}
+
+.journey-map__route-progress[data-state='idle'] {
+  opacity: 0.35;
+}
+
+.journey-map__route-progress[data-state='animating'],
+.journey-map__route-progress[data-state='complete'] {
+  stroke-dashoffset: 0;
+  opacity: 1;
+}
+
+.journey-map__route-node {
+  fill: rgba(255, 102, 196, 0.85);
+  stroke: rgba(5, 5, 22, 0.8);
+  stroke-width: 0.6;
+}
+
+.journey-map__route-node--end {
+  fill: rgba(77, 123, 255, 0.9);
+}
+
 .journey-map__plane {
   position: absolute;
-  top: 50%;
-  left: 12%;
+  top: var(--plane-from-y, 50%);
+  left: var(--plane-from-x, 12%);
   width: 48px;
   height: 48px;
   transform: translate(-50%, -50%) rotate(-6deg);
@@ -951,14 +1041,37 @@
 }
 
 .journey-map__plane[data-state='complete'] {
-  left: 88%;
+  left: var(--plane-to-x, 88%);
+  top: var(--plane-to-y, 50%);
   transform: translate(-50%, -50%) rotate(9deg);
 }
 
 .journey-map__plane--static {
   animation: none !important;
-  left: 88% !important;
+  left: var(--plane-to-x, 88%) !important;
+  top: var(--plane-to-y, 50%) !important;
   transform: translate(-50%, -50%) rotate(6deg) !important;
+}
+
+.journey-map__plane--route {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: rgba(6, 8, 24, 0.6);
+  border: 1px solid rgba(163, 174, 255, 0.3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  filter: none;
+  color: #f5f4ff;
+}
+
+.journey-map__plane--route[data-state='animating'] {
+  animation: none;
+}
+
+.journey-map__route-icon {
+  font-size: 1.35rem;
 }
 
 .journey-map__labels {
@@ -1126,6 +1239,12 @@
   color: rgba(245, 244, 255, 0.85);
 }
 
+.journey-card__text-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
 .journey-card__stats {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -1146,6 +1265,113 @@
   font-weight: 600;
 }
 
+.journey-card__meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem 1.2rem;
+  margin: 1rem 0 0;
+  padding-top: 0.85rem;
+  border-top: 1px solid rgba(163, 174, 255, 0.16);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.6);
+}
+
+.journey-card__meta-grid dt {
+  margin: 0;
+}
+
+.journey-card__meta-grid dd {
+  margin: 0.35rem 0 0;
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  color: rgba(245, 244, 255, 0.9);
+}
+
+.journey-card__meta-note dd {
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.journey-memory-intro {
+  width: 100%;
+  padding: 2.4rem 1.6rem;
+  border-radius: 1.6rem;
+  border: 1px solid rgba(163, 174, 255, 0.25);
+  background: linear-gradient(150deg, rgba(21, 25, 64, 0.92), rgba(9, 12, 38, 0.95));
+  box-shadow: 0 22px 40px rgba(4, 6, 22, 0.45);
+  color: #f5f4ff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.35rem;
+  text-align: center;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.journey-memory-intro:active {
+  transform: scale(0.98);
+}
+
+.journey-memory-intro__subtitle {
+  font-size: 0.78rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+}
+
+.journey-memory-intro__title {
+  font-size: clamp(1.75rem, 6vw, 2.6rem);
+  line-height: 1.25;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.journey-memory-intro__hint {
+  font-size: 0.8rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.7);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.journey-memory-intro__hint::after {
+  content: '›';
+  font-size: 1rem;
+}
+
+.journey-memory__journey {
+  font-size: 0.75rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.65);
+}
+
+.journey-card--memory .journey-card__body {
+  gap: 1.2rem;
+}
+
+.journey-memory__questions {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  margin-top: 1.5rem;
+  padding-top: 1.35rem;
+  border-top: 1px solid rgba(163, 174, 255, 0.18);
+}
+
+.journey-memory__questions-title {
+  margin: 0;
+  font-size: 0.85rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.68);
+}
+
 .journey-prompts {
   display: flex;
   flex-direction: column;
@@ -1157,13 +1383,17 @@
 }
 
 .journey-prompts__locked {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   margin: 0;
-  padding: 0.85rem 1rem;
-  border-radius: 1rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
   border: 1px dashed rgba(163, 174, 255, 0.35);
-  background: rgba(12, 16, 48, 0.55);
-  font-size: 0.85rem;
-  letter-spacing: 0.05em;
+  background: rgba(12, 16, 48, 0.45);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   color: rgba(245, 244, 255, 0.7);
 }
 
@@ -1188,6 +1418,61 @@
   font-size: 0.78rem;
   line-height: 1.5;
   color: rgba(245, 244, 255, 0.65);
+}
+
+.journey-prompt__choices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.journey-choice {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(163, 174, 255, 0.25);
+  background: rgba(6, 8, 24, 0.45);
+  color: #f5f4ff;
+  font-size: 0.92rem;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease, transform 0.2s ease;
+  text-align: left;
+}
+
+.journey-choice:hover,
+.journey-choice:focus-visible {
+  border-color: rgba(255, 102, 196, 0.5);
+  background: rgba(255, 102, 196, 0.12);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.journey-choice.is-selected {
+  border-color: rgba(255, 102, 196, 0.65);
+  background: rgba(255, 102, 196, 0.18);
+}
+
+.journey-choice.is-locked {
+  cursor: default;
+  opacity: 0.75;
+  transform: none;
+  pointer-events: none;
+}
+
+.journey-choice__icon {
+  font-size: 1.05rem;
+  width: 1.2rem;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.journey-choice__label {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.4;
 }
 
 .journey-prompt__input {
@@ -1230,22 +1515,36 @@
   flex-wrap: wrap;
 }
 
-.journey-prompt__toggle {
-  border: none;
-  background: rgba(77, 123, 255, 0.18);
-  color: #f5f4ff;
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
+.journey-prompt__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
 }
 
-.journey-prompt__toggle:active {
-  transform: scale(0.98);
+.journey-prompt__save {
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, rgba(255, 102, 196, 0.92), rgba(77, 123, 255, 0.92));
+  color: #050516;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
+
+.journey-prompt__save:active {
+  transform: translateY(1px);
+}
+
+.journey-prompt__save:disabled {
+  opacity: 0.45;
+  cursor: default;
+  box-shadow: none;
+}
+
 
 .journeys-nav {
   display: flex;
@@ -1295,11 +1594,13 @@
 
 @keyframes plane-fly {
   0% {
-    left: 12%;
+    left: var(--plane-from-x, 12%);
+    top: var(--plane-from-y, 50%);
     transform: translate(-50%, -50%) rotate(-6deg);
   }
   100% {
-    left: 88%;
+    left: var(--plane-to-x, 88%);
+    top: var(--plane-to-y, 50%);
     transform: translate(-50%, -50%) rotate(9deg);
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,10 +102,7 @@ function App() {
   return (
     <div className={`app-shell scene-${currentSceneId}`}>
       {currentSceneId !== 'intro' && <GlobalStarfield />}
-      <DistanceHUD
-        distanceKm={distanceTraveled}
-        goalKm={totalJourneyDistance}
-      />
+      <DistanceHUD distanceKm={distanceTraveled} />
       <main className="scene-container">
         {renderScene(currentSceneId, sceneProps)}
       </main>

--- a/src/data/journeys.json
+++ b/src/data/journeys.json
@@ -1,0 +1,271 @@
+[
+  {
+    "id": "travel-001",
+    "title": "初デート — 福岡での出会い",
+    "date": "2024-10-04",
+    "steps": [
+      {
+        "id": "travel-001-flight",
+        "type": "move",
+        "mode": "flight",
+        "from": "東京 / 成田",
+        "to": "福岡",
+        "distanceKm": 1088,
+        "artKey": "night-sky-market",
+        "fromCoord": [16, 72],
+        "toCoord": [84, 24],
+        "meta": {
+          "flightNo": "JL123",
+          "dep": "07:30",
+          "arr": "09:40"
+        },
+        "description": "成田を飛び立ち、博多の街並みが雲の切れ間に現れた瞬間を共有。"
+      },
+      {
+        "id": "travel-001-episode-airport",
+        "type": "episode",
+        "title": "福岡空港のロビーで初めて手を振った",
+        "artKey": "night-sky-market",
+        "text": [
+          "到着ゲートで見つけた笑顔に、長距離の緊張が一気にほどけた。",
+          "スーツケースの柄を褒め合いながら、ホテルまでの予定を決めた。"
+        ],
+        "photo": {
+          "src": "/images/journey-travel-001-airport.svg",
+          "alt": "夜の空港で待ち合わせるふたりのシルエット",
+          "objectPosition": "center top"
+        }
+      },
+      {
+        "id": "travel-001-walk",
+        "type": "move",
+        "mode": "walk",
+        "from": "福岡空港",
+        "to": "博多駅前ホテル",
+        "distanceKm": 3,
+        "artKey": "night-sky-market",
+        "route": [
+          [20, 72],
+          [36, 68],
+          [54, 64],
+          [68, 58],
+          [78, 52]
+        ],
+        "description": "空港の通路を抜け、夕方の風を浴びながらホテルへ向かった。"
+      },
+      {
+        "id": "travel-001-episode-night",
+        "type": "episode",
+        "title": "初めての夜、博多の街を眺めながら",
+        "artKey": "night-sky-market",
+        "text": [
+          "ホテルの窓際で、空港から持ち帰った香りを分け合った。",
+          "眠る前に次の日の散策ルートを描き合い、胸の高鳴りを共有した。"
+        ],
+        "photo": {
+          "src": "/images/journey-travel-001-night.svg",
+          "alt": "ホテルの窓から見える夜の街並み",
+          "objectPosition": "center"
+        }
+      },
+      {
+        "id": "travel-001-question-food",
+        "type": "question",
+        "style": "choice",
+        "prompt": "初めての食事。セブンイレブンでお互い買ったものは？",
+        "storageKey": "travel-001-food",
+        "choices": [
+          "おにぎり＆ウーロン茶",
+          "サンドイッチ＆カフェラテ",
+          "からあげ棒＆コーラ"
+        ],
+        "readonlyAfterSave": true
+      },
+      {
+        "id": "travel-001-question-feeling",
+        "type": "question",
+        "style": "text",
+        "prompt": "初めての夜、どんな気持ちだった？",
+        "placeholder": "胸に残った言葉をそのまま書き残そう。",
+        "storageKey": "travel-001-feeling",
+        "readonlyAfterSave": true
+      }
+    ]
+  },
+  {
+    "id": "travel-002",
+    "title": "バレンタイン前夜の逆遠征",
+    "date": "2024-02-11",
+    "steps": [
+      {
+        "id": "travel-002-flight",
+        "type": "move",
+        "mode": "flight",
+        "from": "福岡",
+        "to": "羽田",
+        "distanceKm": 1088,
+        "artKey": "valentine-neon",
+        "fromCoord": [18, 70],
+        "toCoord": [82, 22],
+        "meta": {
+          "flightNo": "SKY204",
+          "dep": "19:05",
+          "arr": "21:10"
+        },
+        "description": "夜風とともに羽田へ。手荷物のチョコレートを何度も確認した。"
+      },
+      {
+        "id": "travel-002-episode-city",
+        "type": "episode",
+        "title": "東京の展望デッキで秘密会議",
+        "artKey": "valentine-neon",
+        "text": [
+          "ネオンに照らされた展望デッキで、明日のサプライズの手順を指差しで共有。",
+          "耳元で鳴るアナウンスに紛れて、小さな約束を交わした。"
+        ],
+        "photo": {
+          "src": "/images/journey-travel-002-deck.svg",
+          "alt": "展望デッキから見下ろす夜景とチョコレート"
+        }
+      },
+      {
+        "id": "travel-002-train",
+        "type": "move",
+        "mode": "train",
+        "from": "羽田空港",
+        "to": "渋谷",
+        "distanceKm": 18,
+        "artKey": "valentine-neon",
+        "route": [
+          [18, 64],
+          [30, 56],
+          [42, 48],
+          [55, 38],
+          [72, 28]
+        ],
+        "meta": {
+          "note": "空港線から渋谷まで乗り換え1回。"
+        },
+        "description": "モノレールから見える街の灯りに、到着後のプランを重ねた。"
+      },
+      {
+        "id": "travel-002-question-feeling",
+        "type": "question",
+        "style": "text",
+        "prompt": "この夜に考えていたことは？",
+        "storageKey": "travel-002-feeling",
+        "placeholder": "展望デッキで浮かんだ想いをメモしよう。",
+        "readonlyAfterSave": true
+      },
+      {
+        "id": "travel-002-question-plan",
+        "type": "question",
+        "style": "choice",
+        "prompt": "サプライズの最終確認で約束したのは？",
+        "storageKey": "travel-002-plan",
+        "choices": [
+          "待ち合わせ場所で同時にチョコを渡す",
+          "渋谷駅でカフェに寄って一息つく",
+          "0時ぴったりにメッセージを送る"
+        ],
+        "readonlyAfterSave": true
+      }
+    ]
+  },
+  {
+    "id": "travel-003",
+    "title": "流星群と夏祭りのフィナーレ",
+    "date": "2024-07-27",
+    "steps": [
+      {
+        "id": "travel-003-flight",
+        "type": "move",
+        "mode": "flight",
+        "from": "東京",
+        "to": "福岡",
+        "distanceKm": 1088,
+        "artKey": "stardust-finale",
+        "fromCoord": [14, 68],
+        "toCoord": [86, 26],
+        "meta": {
+          "flightNo": "ANA271",
+          "dep": "16:20",
+          "arr": "18:25"
+        },
+        "description": "夕焼けが翼を染め、着陸前に見えた祭りの灯りに心が踊った。"
+      },
+      {
+        "id": "travel-003-bus",
+        "type": "move",
+        "mode": "bus",
+        "from": "福岡空港",
+        "to": "河川敷の夏祭り会場",
+        "distanceKm": 12,
+        "artKey": "stardust-finale",
+        "route": [
+          [22, 70],
+          [36, 64],
+          [48, 56],
+          [62, 46],
+          [74, 34],
+          [82, 26]
+        ],
+        "meta": {
+          "note": "臨時バスで30分ほどの移動。"
+        },
+        "description": "車窓に映る提灯を指差しながら、到着後の屋台巡りを決めた。"
+      },
+      {
+        "id": "travel-003-episode-festival",
+        "type": "episode",
+        "title": "夏祭りで浴衣の袖が触れた",
+        "artKey": "stardust-finale",
+        "text": [
+          "花火の音と流星群の光が重なる瞬間、互いの手を強く握り直した。",
+          "帰り道の河川敷で、最後の再会に向けて静かに言葉を紡いだ。"
+        ],
+        "photo": {
+          "src": "/images/journey-travel-003-festival.svg",
+          "alt": "夏祭りの提灯と流星群が写った写真"
+        }
+      },
+      {
+        "id": "travel-003-episode-letter",
+        "type": "episode",
+        "title": "夜風に溶ける手紙",
+        "artKey": "stardust-finale",
+        "text": [
+          "屋台の裏で交換した手紙を読み終え、涙を拭いて笑い合った。",
+          "封筒の端に書かれた小さなサインを、記念にそっと撫でた。"
+        ],
+        "photo": {
+          "src": "/images/journey-travel-003-letter.svg",
+          "alt": "ライトアップされた川辺と手紙の封筒",
+          "objectPosition": "center bottom"
+        }
+      },
+      {
+        "id": "travel-003-question-highlight",
+        "type": "question",
+        "style": "choice",
+        "prompt": "一番心に残った瞬間は？",
+        "storageKey": "travel-003-highlight",
+        "choices": [
+          "流星群を見上げた瞬間",
+          "屋台で食べたかき氷",
+          "手紙を交換したとき"
+        ],
+        "readonlyAfterSave": true
+      },
+      {
+        "id": "travel-003-question-feeling",
+        "type": "question",
+        "style": "text",
+        "prompt": "最後に伝えた言葉を覚えてる？",
+        "storageKey": "travel-003-feeling",
+        "placeholder": "夜風と一緒に流れた想いをメモしよう。",
+        "readonlyAfterSave": true
+      }
+    ]
+  }
+]

--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -1,159 +1,16 @@
 import type { Journey } from '../types/journey'
+import journeySource from './journeys.json' assert { type: 'json' }
 
 type JourneyInput = Omit<Journey, 'distanceKm'>
 
-const journeyDefinitions: JourneyInput[] = [
-  {
-    id: 'journey-2023-autumn',
-    title: '空フェス夜市が始まった夜',
-    date: '2023-10-14',
-    steps: [
-      {
-        id: '2023-autumn-flight',
-        type: 'move',
-        from: 'Tokyo',
-        to: 'Fukuoka',
-        transport: 'plane',
-        distanceKm: 1080,
-        artKey: 'night-sky-market',
-        description: '羽田からネオン色の夜市へ。機内アナウンスが幕開けを告げた。',
-      },
-      {
-        id: '2023-autumn-market',
-        type: 'episode',
-        title: '空フェス夜市で再会',
-        caption:
-          '提灯が揺れるアーケードで、互いの歩幅が自然に揃った。写真を撮るたびに笑い声が重なる。',
-        artKey: 'night-sky-market',
-        media: {
-          src: 'https://images.placeholders.dev/?width=640&height=900&text=Night+Market',
-          alt: '夜市のネオンとふたりの影が写る写真',
-          objectPosition: 'center top',
-        },
-      },
-      {
-        id: '2023-autumn-question-feeling',
-        type: 'question',
-        prompt: 'このときどう思った？',
-        placeholder: '屋台の匂いや風のあたたかさを、好きな言葉で書き残そう。',
-        helper: '回答はローカルに保存され、Resultでそのまま表示されます。',
-      },
-      {
-        id: '2023-autumn-question-highlight',
-        type: 'question',
-        prompt: '一番印象に残った瞬間は？',
-        placeholder: 'ネオンが弾けた瞬間、ふたりで見た景色は？',
-      },
-    ],
-  },
-  {
-    id: 'journey-2024-valentine',
-    title: 'バレンタイン前夜の逆遠征',
-    date: '2024-02-11',
-    steps: [
-      {
-        id: '2024-valentine-flight',
-        type: 'move',
-        from: 'Fukuoka',
-        to: 'Tokyo',
-        transport: 'plane',
-        distanceKm: 1080,
-        artKey: 'valentine-neon',
-        description: '福岡の夜風を背に、チョコレートを抱えて羽田へ向かう。',
-      },
-      {
-        id: '2024-valentine-city',
-        type: 'episode',
-        title: '東京の夜景と秘密の計画',
-        caption:
-          '展望デッキから眺める街はピンクとブルーのグラデーション。明日のサプライズ手順をこっそり指差しで確認した。',
-        artKey: 'valentine-neon',
-        media: {
-          src: 'https://images.placeholders.dev/?width=640&height=900&text=Tokyo+Neon',
-          alt: '東京の夜景と渡す予定のチョコレート',
-        },
-      },
-      {
-        id: '2024-valentine-question-feeling',
-        type: 'question',
-        prompt: 'このときどう思った？',
-        placeholder: '展望デッキで考えていたこと、胸の高鳴りを書き残そう。',
-      },
-      {
-        id: '2024-valentine-question-highlight',
-        type: 'question',
-        prompt: '一番印象に残った瞬間は？',
-        placeholder: 'チョコを渡すタイミング？それとも夜景？',
-      },
-    ],
-  },
-  {
-    id: 'journey-2024-summer',
-    title: '流星群と夏祭りのフィナーレ',
-    date: '2024-07-27',
-    steps: [
-      {
-        id: '2024-summer-flight',
-        type: 'move',
-        from: 'Tokyo',
-        to: 'Fukuoka',
-        transport: 'plane',
-        distanceKm: 1080,
-        artKey: 'stardust-finale',
-        description: '夏の雲を突き抜けて福岡へ。コックピットの窓に夕焼けが反射する。',
-      },
-      {
-        id: '2024-summer-festival',
-        type: 'episode',
-        title: '夏祭りと流星のシャワー',
-        caption:
-          '浴衣の袖が触れるたびに、屋台の光がぼやける。流星群を浴びながら、最後の再会をゆっくり噛み締めた。',
-        artKey: 'stardust-finale',
-        media: {
-          src: 'https://images.placeholders.dev/?width=640&height=900&text=Summer+Festival',
-          alt: '夜空に流れる流星群と夏祭りの提灯',
-          objectPosition: 'center',
-        },
-      },
-      {
-        id: '2024-summer-bonus',
-        type: 'episode',
-        title: '夜風に溶ける手紙',
-        caption:
-          '屋台の裏で交換した手紙。封を開ける指先が震えて、笑いながら握り直した。',
-        artKey: 'stardust-finale',
-        media: {
-          src: 'https://images.placeholders.dev/?width=640&height=900&text=Letter+Exchange',
-          alt: 'ライトアップされた川辺と手紙の封筒',
-          objectPosition: 'center bottom',
-        },
-      },
-      {
-        id: '2024-summer-question-feeling',
-        type: 'question',
-        prompt: 'このときどう思った？',
-        placeholder: '流星の瞬きとリンクした感情をメモ。',
-      },
-      {
-        id: '2024-summer-question-highlight',
-        type: 'question',
-        prompt: '一番印象に残った瞬間は？',
-        placeholder: '夏の夜を締めくくったシーンを書き残そう。',
-      },
-    ],
-  },
-]
+type JourneyStepWithDistance = JourneyInput['steps'][number]
 
-export const journeys: Journey[] = journeyDefinitions.map((journey) => {
-  const distanceKm = journey.steps.reduce((total, step) => {
-    if (step.type === 'move') {
-      return total + step.distanceKm
-    }
-    return total
-  }, 0)
+const computeJourneyDistance = (steps: JourneyStepWithDistance[]): number =>
+  steps.reduce((total, step) => (step.type === 'move' ? total + step.distanceKm : total), 0)
 
-  return {
-    ...journey,
-    distanceKm,
-  }
-})
+const journeyDefinitions = journeySource as JourneyInput[]
+
+export const journeys: Journey[] = journeyDefinitions.map((journey) => ({
+  ...journey,
+  distanceKm: computeJourneyDistance(journey.steps),
+}))

--- a/src/hooks/useStoredJourneyResponses.ts
+++ b/src/hooks/useStoredJourneyResponses.ts
@@ -30,6 +30,7 @@ const readFromStorage = (): JourneyPromptResponse[] => {
         typeof entry === 'object' &&
         typeof entry.journeyId === 'string' &&
         typeof entry.stepId === 'string' &&
+        typeof entry.storageKey === 'string' &&
         typeof entry.prompt === 'string' &&
         typeof entry.answer === 'string' &&
         typeof entry.recordedAt === 'string'
@@ -61,11 +62,7 @@ export const useStoredJourneyResponses = () => {
     (payload: SaveJourneyResponsePayload) => {
       setResponses((prev) => {
         const filtered = prev.filter(
-          (entry) =>
-            !(
-              entry.journeyId === payload.journeyId &&
-              entry.stepId === payload.stepId
-            )
+          (entry) => entry.storageKey !== payload.storageKey
         )
 
         const updated: JourneyPromptResponse = {

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -4,16 +4,18 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
 } from 'react'
 
 import { SceneLayout } from '../components/SceneLayout'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import type {
   Journey,
+  JourneyCoordinate,
   JourneyEpisodeStep,
+  JourneyMoveMode,
   JourneyMoveStep,
   JourneyQuestionStep,
-  JourneyStep,
 } from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
 
@@ -63,11 +65,12 @@ const formatRecordedAt = (value?: string) => {
   return timestampFormatter.format(date)
 }
 
-const transportMeta = {
-  plane: { label: 'AIR ROUTE', icon: '✈️' },
-  train: { label: 'TRAIN ROUTE', icon: '🚅' },
-  bus: { label: 'BUS ROUTE', icon: '🚌' },
-} as const
+const transportMeta: Record<JourneyMoveMode, { label: string; icon: string }> = {
+  flight: { label: 'FLIGHT', icon: '✈️' },
+  walk: { label: 'WALK', icon: '🚶' },
+  bus: { label: 'BUS', icon: '🚌' },
+  train: { label: 'TRAIN', icon: '🚆' },
+}
 
 const artBackgrounds: Record<string, string> = {
   'night-sky-market':
@@ -81,12 +84,12 @@ const artBackgrounds: Record<string, string> = {
 const defaultArtBackground =
   'linear-gradient(150deg, rgba(20, 24, 60, 0.92), rgba(8, 10, 32, 0.95))'
 
-const getArtBackground = (key: string) => artBackgrounds[key] ?? defaultArtBackground
+const getArtBackground = (key?: string) =>
+  (key ? artBackgrounds[key] : undefined) ?? defaultArtBackground
 
-const stepTypeLabel: Record<JourneyStep['type'], string> = {
+const stepTypeLabel: Record<'move' | 'memory', string> = {
   move: '移動',
-  episode: '思い出',
-  question: '記録',
+  memory: '思い出',
 }
 
 type MoveMeta = {
@@ -120,16 +123,105 @@ const buildMoveMetas = (journeyList: Journey[]): MoveMeta[] => {
   return result
 }
 
-const isMoveStep = (step: JourneyStep | undefined): step is JourneyMoveStep =>
-  step?.type === 'move'
+type JourneyDisplayStep =
+  | { kind: 'move'; move: JourneyMoveStep }
+  | { kind: 'memory'; episode: JourneyEpisodeStep; questions: JourneyQuestionStep[] }
 
-const isEpisodeStep = (
-  step: JourneyStep | undefined
-): step is JourneyEpisodeStep => step?.type === 'episode'
+const isMoveDisplayStep = (
+  step: JourneyDisplayStep | undefined
+): step is { kind: 'move'; move: JourneyMoveStep } => step?.kind === 'move'
 
-const isQuestionStep = (
-  step: JourneyStep | undefined
-): step is JourneyQuestionStep => step?.type === 'question'
+const isMemoryDisplayStep = (
+  step: JourneyDisplayStep | undefined
+): step is { kind: 'memory'; episode: JourneyEpisodeStep; questions: JourneyQuestionStep[] } =>
+  step?.kind === 'memory'
+
+const buildDisplaySteps = (journey: Journey): JourneyDisplayStep[] => {
+  const displaySteps: JourneyDisplayStep[] = []
+
+  for (let index = 0; index < journey.steps.length; index += 1) {
+    const step = journey.steps[index]
+    if (step.type === 'move') {
+      displaySteps.push({ kind: 'move', move: step })
+      continue
+    }
+
+    if (step.type === 'episode') {
+      const questions: JourneyQuestionStep[] = []
+      let lookahead = index + 1
+
+      while (lookahead < journey.steps.length) {
+        const nextStep = journey.steps[lookahead]
+        if (nextStep.type === 'question') {
+          questions.push(nextStep)
+          lookahead += 1
+          continue
+        }
+        break
+      }
+
+      displaySteps.push({ kind: 'memory', episode: step, questions })
+      index = lookahead - 1
+      continue
+    }
+
+    if (step.type === 'question') {
+      const previous = displaySteps[displaySteps.length - 1]
+      if (previous && previous.kind === 'memory') {
+        previous.questions.push(step)
+      } else {
+        displaySteps.push({
+          kind: 'memory',
+          episode: {
+            id: `${step.id}-memory`,
+            type: 'episode',
+            title: journey.title,
+            text: [step.prompt],
+            photo: {
+              src: '',
+              alt: '',
+            },
+          },
+          questions: [step],
+        })
+      }
+    }
+  }
+
+  return displaySteps
+}
+
+const defaultRoute: JourneyCoordinate[] = [
+  [12, 78],
+  [28, 66],
+  [50, 54],
+  [72, 42],
+  [88, 28],
+]
+
+const getRoutePoints = (step: JourneyMoveStep): JourneyCoordinate[] => {
+  if (step.route && step.route.length >= 2) {
+    return step.route
+  }
+
+  if (step.fromCoord && step.toCoord) {
+    return [step.fromCoord, step.toCoord]
+  }
+
+  return defaultRoute
+}
+
+const toRoutePath = (points: JourneyCoordinate[]): string => {
+  if (!points.length) {
+    return ''
+  }
+
+  const [first, ...rest] = points
+  return rest.reduce(
+    (acc, point) => `${acc} L ${point[0]} ${point[1]}`,
+    `M ${first[0]} ${first[1]}`
+  )
+}
 
 export const JourneysScene = ({
   onAdvance,
@@ -154,29 +246,28 @@ export const JourneysScene = ({
   const responseMap = useMemo(() => {
     const map = new Map<string, typeof responses[number]>()
     responses.forEach((entry) => {
-      map.set(`${entry.journeyId}:${entry.stepId}`, entry)
+      map.set(entry.storageKey, entry)
     })
     return map
   }, [responses])
 
   const [activeJourneyIndex, setActiveJourneyIndex] = useState(0)
   const [activeStepIndex, setActiveStepIndex] = useState(0)
-  const [animationState, setAnimationState] = useState<'idle' | 'animating' | 'complete'>(
-    'idle'
-  )
+  const [animationState, setAnimationState] = useState<
+    'idle' | 'animating' | 'complete'
+  >('idle')
   const animationTimeoutRef = useRef<number | null>(null)
   const [animationToken, setAnimationToken] = useState(0)
-  const [draftAnswer, setDraftAnswer] = useState('')
-  const [editingStepKey, setEditingStepKey] = useState<string | null>(null)
+  const [memoryIntroVisible, setMemoryIntroVisible] = useState(false)
+  const [draftAnswers, setDraftAnswers] = useState<Record<string, string>>({})
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    return () => {
       if (animationTimeoutRef.current !== null) {
         window.clearTimeout(animationTimeoutRef.current)
       }
-    },
-    []
-  )
+    }
+  }, [])
 
   useEffect(() => {
     if (journeys.length === 0) {
@@ -191,39 +282,72 @@ export const JourneysScene = ({
     }
   }, [activeJourneyIndex, journeys])
 
+  const activeJourney = journeys[activeJourneyIndex]
+
+  const displaySteps = useMemo(
+    () => (activeJourney ? buildDisplaySteps(activeJourney) : []),
+    [activeJourney]
+  )
+
   useEffect(() => {
-    const journey = journeys[activeJourneyIndex]
-    if (!journey) {
+    if (!activeJourney) {
       setActiveStepIndex(0)
       return
     }
 
-    if (activeStepIndex >= journey.steps.length) {
-      setActiveStepIndex(Math.max(journey.steps.length - 1, 0))
+    if (activeStepIndex >= displaySteps.length) {
+      setActiveStepIndex(Math.max(displaySteps.length - 1, 0))
     }
-  }, [activeJourneyIndex, activeStepIndex, journeys])
+  }, [activeJourney, activeStepIndex, displaySteps.length])
 
-  const activeJourney = journeys[activeJourneyIndex]
-  const activeStep = activeJourney?.steps[activeStepIndex]
-
-  const stepKey = activeJourney && activeStep ? `${activeJourney.id}:${activeStep.id}` : ''
-  const storedResponse = stepKey ? responseMap.get(stepKey) : undefined
-  const isEditing = stepKey && editingStepKey === stepKey
+  const activeStep = displaySteps[activeStepIndex]
 
   useEffect(() => {
-    if (isQuestionStep(activeStep) && activeJourney) {
-      const key = `${activeJourney.id}:${activeStep.id}`
-      const stored = responseMap.get(key)
-      setDraftAnswer(stored?.answer ?? '')
-      setEditingStepKey(stored ? null : key)
+    if (isMemoryDisplayStep(activeStep)) {
+      setMemoryIntroVisible(true)
     } else {
-      setDraftAnswer('')
-      setEditingStepKey(null)
+      setMemoryIntroVisible(false)
     }
-  }, [activeJourney, activeStep, responseMap])
+  }, [activeStep])
 
   useEffect(() => {
-    if (!isMoveStep(activeStep)) {
+    if (!activeJourney) {
+      return
+    }
+
+    setDraftAnswers((prev) => {
+      let changed = false
+      const nextDrafts = { ...prev }
+
+      activeJourney.steps.forEach((step) => {
+        if (step.type !== 'question') {
+          return
+        }
+
+        const stored = responseMap.get(step.storageKey)
+        if (stored) {
+          if (nextDrafts[step.id] !== stored.answer) {
+            nextDrafts[step.id] = stored.answer
+            changed = true
+          }
+          return
+        }
+
+        if (!(step.id in nextDrafts)) {
+          nextDrafts[step.id] = ''
+          changed = true
+        }
+      })
+
+      return changed ? nextDrafts : prev
+    })
+  }, [activeJourney, responseMap])
+
+  const moveStep = isMoveDisplayStep(activeStep) ? activeStep.move : undefined
+  const memoryStep = isMemoryDisplayStep(activeStep) ? activeStep : undefined
+
+  useEffect(() => {
+    if (!moveStep) {
       if (animationTimeoutRef.current !== null) {
         window.clearTimeout(animationTimeoutRef.current)
         animationTimeoutRef.current = null
@@ -232,7 +356,7 @@ export const JourneysScene = ({
       return
     }
 
-    const meta = moveMetaMap.get(activeStep.id)
+    const meta = moveMetaMap.get(moveStep.id)
     if (!meta) {
       setAnimationState('idle')
       return
@@ -243,31 +367,53 @@ export const JourneysScene = ({
     } else {
       setAnimationState('idle')
     }
-  }, [activeStep, distanceTraveled, moveMetaMap])
+  }, [moveStep, distanceTraveled, moveMetaMap])
 
   const completedDistance = Math.min(distanceTraveled, totalJourneyDistance)
-  const remainingDistance = Math.max(totalJourneyDistance - completedDistance, 0)
 
   const progressPercent = totalJourneyDistance
     ? Math.min(100, Math.max(0, (completedDistance / totalJourneyDistance) * 100))
     : 0
 
-  const moveMeta = isMoveStep(activeStep)
-    ? moveMetaMap.get(activeStep.id)
-    : undefined
+  const moveMeta = moveStep ? moveMetaMap.get(moveStep.id) : undefined
 
   const isMoveCompleted = moveMeta
     ? completedDistance >= moveMeta.cumulativeAfter - COMPLETION_EPSILON
     : false
 
-  const planeState: 'idle' | 'animating' | 'complete' = animationState
+  const transport = moveStep ? transportMeta[moveStep.mode] : undefined
+
+  const statusLabel = (() => {
+    if (!moveStep) {
+      return ''
+    }
+
+    if (animationState === 'animating') {
+      return '移動中…'
+    }
+
+    if (isMoveCompleted) {
+      return '到着済み — 思い出をめくろう'
+    }
+
+    if (moveStep.mode === 'flight' && moveStep.meta?.flightNo) {
+      const times = [moveStep.meta.dep, moveStep.meta.arr]
+        .filter(Boolean)
+        .join(' → ')
+      return times
+        ? `${moveStep.meta.flightNo} ${times} (タップ)`
+        : `${moveStep.meta.flightNo} (タップ)`
+    }
+
+    return `${moveStep.from} → ${moveStep.to} を開始 (タップ)`
+  })()
 
   const handleStartMove = () => {
-    if (!isMoveStep(activeStep) || !activeJourney) {
+    if (!moveStep) {
       return
     }
 
-    const meta = moveMetaMap.get(activeStep.id)
+    const meta = moveMetaMap.get(moveStep.id)
     if (!meta) {
       return
     }
@@ -319,10 +465,10 @@ export const JourneysScene = ({
 
     const nextJourneyIndex = activeJourneyIndex - 1
     const nextJourney = journeys[nextJourneyIndex]
-    const nextStepIndex = Math.max((nextJourney?.steps.length ?? 1) - 1, 0)
+    const nextDisplaySteps = buildDisplaySteps(nextJourney)
 
     setActiveJourneyIndex(nextJourneyIndex)
-    setActiveStepIndex(nextStepIndex)
+    setActiveStepIndex(Math.max(nextDisplaySteps.length - 1, 0))
   }
 
   const handleNextStep = () => {
@@ -331,7 +477,12 @@ export const JourneysScene = ({
       return
     }
 
-    if (activeStepIndex < activeJourney.steps.length - 1) {
+    if (memoryStep && memoryIntroVisible) {
+      setMemoryIntroVisible(false)
+      return
+    }
+
+    if (activeStepIndex < displaySteps.length - 1) {
       setActiveStepIndex((index) => index + 1)
       return
     }
@@ -346,34 +497,37 @@ export const JourneysScene = ({
     setActiveStepIndex(0)
   }
 
-  const handleToggleEditing = () => {
-    if (!isQuestionStep(activeStep) || !activeJourney || !stepKey) {
+  const handleRevealMemory = () => {
+    if (!memoryStep) {
       return
     }
-
-    setEditingStepKey((current) => (current === stepKey ? null : stepKey))
+    setMemoryIntroVisible(false)
   }
 
-  const handleAnswerChange = useCallback(
-    (value: string) => {
-      if (!isQuestionStep(activeStep) || !activeJourney) {
+  const handleQuestionDraftChange = useCallback((questionId: string, value: string) => {
+    setDraftAnswers((prev) => ({ ...prev, [questionId]: value }))
+  }, [])
+
+  const handleQuestionSave = useCallback(
+    (question: JourneyQuestionStep) => {
+      if (!activeJourney) {
         return
       }
 
-      const key = `${activeJourney.id}:${activeStep.id}`
-      if (storedResponse && editingStepKey !== key) {
+      const answer = draftAnswers[question.id] ?? ''
+      if (!answer.trim()) {
         return
       }
 
-      setDraftAnswer(value)
       saveResponse({
         journeyId: activeJourney.id,
-        stepId: activeStep.id,
-        prompt: activeStep.prompt,
-        answer: value,
+        stepId: question.id,
+        storageKey: question.storageKey,
+        prompt: question.prompt,
+        answer,
       })
     },
-    [activeJourney, activeStep, editingStepKey, saveResponse, storedResponse]
+    [activeJourney, draftAnswers, saveResponse]
   )
 
   if (!activeJourney || !activeStep) {
@@ -390,45 +544,53 @@ export const JourneysScene = ({
     )
   }
 
-  const transport = isMoveStep(activeStep)
-    ? transportMeta[activeStep.transport]
-    : undefined
-
-  const statusLabel = (() => {
-    if (!isMoveStep(activeStep)) {
-      return ''
-    }
-
-    if (animationState === 'animating') {
-      return '移動中…'
-    }
-
-    if (isMoveCompleted) {
-      return '到着済み — 記録を残そう'
-    }
-
-    return `${activeStep.from} → ${activeStep.to} を開始 (タップ)`
-  })()
-
   const isFinalJourney =
     activeJourneyIndex === journeys.length - 1 && journeys.length > 0
   const isFinalStep =
-    isFinalJourney && activeStepIndex === activeJourney.steps.length - 1
+    isFinalJourney && activeStepIndex === displaySteps.length - 1
 
-  const nextButtonLabel = isFinalStep
+  const baseNextLabel = isFinalStep
     ? 'Messagesへ進む'
-    : activeStepIndex === activeJourney.steps.length - 1
+    : activeStepIndex === displaySteps.length - 1
       ? '次の旅へ'
-      : '次のステップ'
+      : '次のページ'
+
+  const nextButtonLabel =
+    memoryStep && memoryIntroVisible ? '思い出をひらく' : baseNextLabel
 
   const prevDisabled = activeJourneyIndex === 0 && activeStepIndex === 0
-  const nextDisabled = isMoveStep(activeStep) && !isMoveCompleted
+  const nextDisabled =
+    isMoveDisplayStep(activeStep) && !isMoveCompleted
+
+  const planeStyle: CSSProperties | undefined =
+    moveStep && moveStep.mode === 'flight'
+      ? {
+          ['--plane-from-x' as string]: `${moveStep.fromCoord?.[0] ?? 12}%`,
+          ['--plane-from-y' as string]: `${moveStep.fromCoord?.[1] ?? 50}%`,
+          ['--plane-to-x' as string]: `${moveStep.toCoord?.[0] ?? 88}%`,
+          ['--plane-to-y' as string]: `${moveStep.toCoord?.[1] ?? 50}%`,
+        }
+      : undefined
+
+  const routePoints =
+    moveStep && moveStep.mode !== 'flight' ? getRoutePoints(moveStep) : []
+  const routePath =
+    moveStep && moveStep.mode !== 'flight' ? toRoutePath(routePoints) : ''
+
+  const routeStart = routePoints[0]
+  const routeEnd = routePoints[routePoints.length - 1]
+
+  const headerMode = transport
+    ? transport
+    : memoryStep
+      ? { icon: '📖', label: 'MEMORY' }
+      : undefined
 
   return (
     <SceneLayout
       eyebrow="Journeys"
-      title="移動演出と思い出ギャラリー"
-      description="東京⇄福岡の移動をタップで辿り、到着ごとに写真と質問へ答えを残していきます。"
+      title="旅の移動演出ログ"
+      description="この一年で実際に会いに行った旅を、移動演出と思い出で振り返ります。"
     >
       <div className="journeys-experience">
         <header className="journeys-header">
@@ -442,9 +604,20 @@ export const JourneysScene = ({
           </div>
           <h2 className="journeys-header__title">{activeJourney.title}</h2>
           <p className="journeys-header__step">
-            STEP {activeStepIndex + 1}/{activeJourney.steps.length} ·{' '}
-            {stepTypeLabel[activeStep.type]}
+            PAGE {activeStepIndex + 1}/{displaySteps.length} ·{' '}
+            {stepTypeLabel[activeStep.kind]}
           </p>
+          <div className="journeys-header__meta">
+            <span className="journeys-header__date">
+              {formatJourneyDate(activeJourney.date)}
+            </span>
+            {headerMode ? (
+              <span className="journeys-header__mode">
+                <span aria-hidden="true">{headerMode.icon}</span>
+                {headerMode.label}
+              </span>
+            ) : null}
+          </div>
           <div className="journeys-progress-bar" aria-hidden="true">
             <div
               className="journeys-progress-bar__fill"
@@ -452,7 +625,9 @@ export const JourneysScene = ({
             />
           </div>
           <div className="journeys-step-indicator" aria-hidden="true">
-            {activeJourney.steps.map((step, index) => {
+            {displaySteps.map((step, index) => {
+              const key =
+                step.kind === 'move' ? step.move.id : step.episode.id
               const className = [
                 'journeys-step-indicator__dot',
                 index === activeStepIndex
@@ -464,76 +639,107 @@ export const JourneysScene = ({
                 .filter(Boolean)
                 .join(' ')
 
-              return <span key={step.id} className={className} />
+              return <span key={key} className={className} />
             })}
-          </div>
-          <div className="journeys-header__secondary">
-            <span>残り {formatDistance(remainingDistance)} km</span>
-            <span>
-              {isMoveCompleted
-                ? `到着済み: ${formatDistance(
-                    moveMeta?.cumulativeAfter ?? completedDistance
-                  )} km`
-                : `出発前: ${formatDistance(
-                    moveMeta?.cumulativeBefore ?? completedDistance
-                  )} km`}
-            </span>
           </div>
         </header>
 
         <div className="journeys-stage">
-          {isMoveStep(activeStep) ? (
+          {moveStep ? (
             <>
               <button
                 type="button"
-                className="journey-map"
+                className={`journey-map${
+                  moveStep.mode !== 'flight' ? ' journey-map--route' : ''
+                }`}
                 onClick={handleStartMove}
                 disabled={animationState === 'animating'}
                 aria-live="polite"
-                aria-label={`${activeStep.from}から${activeStep.to}への移動を開始`}
-                style={{ background: getArtBackground(activeStep.artKey) }}
+                aria-label={`${moveStep.from}から${moveStep.to}への移動を開始`}
+                style={{ background: getArtBackground(moveStep.artKey) }}
               >
                 <span className="journey-map__glow" aria-hidden="true" />
-                <div className="journey-map__line" aria-hidden="true">
-                  <span className="journey-map__line-track" />
-                  <span
-                    key={`progress-${activeStep.id}-${animationToken}-${planeState}`}
-                    className="journey-map__line-progress"
-                    data-state={planeState}
-                  />
-                </div>
+                {moveStep.mode === 'flight' ? (
+                  <div className="journey-map__line" aria-hidden="true">
+                    <span className="journey-map__line-track" />
+                    <span
+                      key={`progress-${moveStep.id}-${animationToken}-${animationState}`}
+                      className="journey-map__line-progress"
+                      data-state={animationState}
+                    />
+                  </div>
+                ) : (
+                  <div className="journey-map__route-visual" aria-hidden="true">
+                    <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
+                      <path className="journey-map__route-track" d={routePath} />
+                      <path
+                        key={`route-${moveStep.id}-${animationToken}-${animationState}`}
+                        className="journey-map__route-progress"
+                        data-state={animationState}
+                        d={routePath}
+                      />
+                      {routeStart ? (
+                        <circle
+                          className="journey-map__route-node"
+                          cx={routeStart[0]}
+                          cy={routeStart[1]}
+                          r={2.2}
+                        />
+                      ) : null}
+                      {routeEnd ? (
+                        <circle
+                          className="journey-map__route-node journey-map__route-node--end"
+                          cx={routeEnd[0]}
+                          cy={routeEnd[1]}
+                          r={2.8}
+                        />
+                      ) : null}
+                    </svg>
+                  </div>
+                )}
                 <span
-                  key={`plane-${activeStep.id}-${animationToken}-${planeState}`}
+                  key={`plane-${moveStep.id}-${animationToken}-${animationState}`}
                   className={`journey-map__plane${
-                    prefersReducedMotion && planeState === 'complete'
+                    moveStep.mode !== 'flight'
+                      ? ' journey-map__plane--route'
+                      : ''
+                  }${
+                    prefersReducedMotion && animationState === 'complete'
                       ? ' journey-map__plane--static'
                       : ''
                   }`}
-                  data-state={planeState}
+                  data-state={animationState}
                   aria-hidden="true"
+                  style={planeStyle}
                 >
-                  <svg viewBox="0 0 60 32" role="img" aria-hidden="true">
-                    <path
-                      d="M2 14h24l8-10h7l-7 10h18l4 2-4 2H34l7 10h-7l-8-10H2l-2-2z"
-                      fill="url(#planeGradient)"
-                    />
-                    <defs>
-                      <linearGradient
-                        id="planeGradient"
-                        x1="0%"
-                        y1="0%"
-                        x2="100%"
-                        y2="100%"
-                      >
-                        <stop offset="0%" stopColor="#ff66c4" />
-                        <stop offset="100%" stopColor="#4d7bff" />
-                      </linearGradient>
-                    </defs>
-                  </svg>
+                  {moveStep.mode === 'flight' ? (
+                    <svg viewBox="0 0 60 32" role="img" aria-hidden="true">
+                      <path
+                        d="M2 14h24l8-10h7l-7 10h18l4 2-4 2H34l7 10h-7l-8-10H2l-2-2z"
+                        fill="url(#planeGradient)"
+                      />
+                      <defs>
+                        <linearGradient
+                          id="planeGradient"
+                          x1="0%"
+                          y1="0%"
+                          x2="100%"
+                          y2="100%"
+                        >
+                          <stop offset="0%" stopColor="#ff66c4" />
+                          <stop offset="100%" stopColor="#4d7bff" />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  ) : (
+                    <span className="journey-map__route-icon" aria-hidden="true">
+                      {transport?.icon ?? '•'}
+                    </span>
+                  )}
                 </span>
                 <div className="journey-map__labels" aria-hidden="true">
-                  <span>{activeStep.from}</span>
-                  <span>{activeStep.to}</span>
+                  <span>{moveStep.from}</span>
+                  <span>{moveStep.to}</span>
                 </div>
                 <span className="journey-map__status">{statusLabel}</span>
               </button>
@@ -553,33 +759,29 @@ export const JourneysScene = ({
                     </span>
                   </div>
                   <div className="journey-card__route">
-                    <span className="journey-card__city">{activeStep.from}</span>
+                    <span className="journey-card__city">{moveStep.from}</span>
                     <span className="journey-card__arrow" aria-hidden="true">
                       →
                     </span>
-                    <span className="journey-card__city">{activeStep.to}</span>
+                    <span className="journey-card__city">{moveStep.to}</span>
                   </div>
                   <div className="journey-card__transport">
                     <span aria-hidden="true">{transport?.icon}</span>
                     <span>{transport?.label}</span>
-                    <span>{formatDistance(activeStep.distanceKm)} km</span>
+                    <span>{formatDistance(moveStep.distanceKm)} km</span>
                   </div>
                   <p className="journey-card__caption">
-                    {activeStep.description ?? activeJourney.title}
+                    {moveStep.description ?? activeJourney.title}
                   </p>
                   <div className="journey-card__stats">
                     <div>
                       <p className="journey-card__stat-label">今回の移動距離</p>
                       <p className="journey-card__stat-value">
-                        {formatDistance(activeStep.distanceKm)} km
+                        {formatDistance(moveStep.distanceKm)} km
                       </p>
                     </div>
                     <div>
-                      <p className="journey-card__stat-label">
-                        {isMoveCompleted
-                          ? '累計距離 (到着済み)'
-                          : '累計距離 (出発前)'}
-                      </p>
+                      <p className="journey-card__stat-label">累計距離</p>
                       <p className="journey-card__stat-value">
                         {formatDistance(
                           isMoveCompleted
@@ -590,106 +792,238 @@ export const JourneysScene = ({
                       </p>
                     </div>
                   </div>
+                  {moveStep.meta ? (
+                    <dl className="journey-card__meta-grid">
+                      {moveStep.meta.flightNo ? (
+                        <div>
+                          <dt>便名</dt>
+                          <dd>{moveStep.meta.flightNo}</dd>
+                        </div>
+                      ) : null}
+                      {moveStep.meta.dep ? (
+                        <div>
+                          <dt>発</dt>
+                          <dd>{moveStep.meta.dep}</dd>
+                        </div>
+                      ) : null}
+                      {moveStep.meta.arr ? (
+                        <div>
+                          <dt>到着</dt>
+                          <dd>{moveStep.meta.arr}</dd>
+                        </div>
+                      ) : null}
+                      {moveStep.meta.note ? (
+                        <div className="journey-card__meta-note">
+                          <dt>NOTE</dt>
+                          <dd>{moveStep.meta.note}</dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  ) : null}
                 </div>
               </article>
             </>
           ) : null}
 
-          {isEpisodeStep(activeStep) ? (
-            <article className="journey-card journey-card--episode">
-              <div
-                className="journey-card__media"
-                style={{ background: getArtBackground(activeStep.artKey) }}
+          {memoryStep ? (
+            memoryIntroVisible ? (
+              <button
+                type="button"
+                className="journey-memory-intro"
+                onClick={handleRevealMemory}
               >
-                <img
-                  className="journey-card__photo"
-                  src={activeStep.media.src}
-                  alt={activeStep.media.alt}
-                  loading="lazy"
-                  style={
-                    activeStep.media.objectPosition
-                      ? { objectPosition: activeStep.media.objectPosition }
-                      : undefined
-                  }
-                />
-                <span className="journey-card__badge">
-                  <span className="journey-card__badge-icon" aria-hidden="true">
-                    ✨
-                  </span>
-                  MEMORIES
+                <span className="journey-memory-intro__subtitle">
+                  {formatJourneyDate(activeJourney.date)}
                 </span>
-              </div>
-              <div className="journey-card__body">
-                <div className="journey-card__meta">
-                  <span className="journey-status journey-status--arrived">
-                    EPISODE
-                  </span>
-                  <span className="journey-card__date">
-                    {formatJourneyDate(activeJourney.date)}
-                  </span>
-                </div>
-                <h3 className="journey-card__episode-title">{activeStep.title}</h3>
-                <p className="journey-card__caption">{activeStep.caption}</p>
-              </div>
-            </article>
-          ) : null}
-
-          {isQuestionStep(activeStep) ? (
-            <article className="journey-card journey-card--question">
-              <div className="journey-card__body">
-                <div className="journey-card__meta">
-                  <span className="journey-status journey-status--arrived">
-                    RECORD
-                  </span>
-                  <span className="journey-card__date">
-                    {formatJourneyDate(activeJourney.date)}
-                  </span>
-                </div>
-                <div className="journey-prompts journey-prompts--single">
-                  <label className="journey-prompt" htmlFor={activeStep.id}>
-                    <span className="journey-prompt__question">
-                      {activeStep.prompt}
-                    </span>
-                    {activeStep.helper ? (
-                      <span className="journey-prompt__helper">
-                        {activeStep.helper}
-                      </span>
-                    ) : null}
-                    <textarea
-                      id={activeStep.id}
-                      className="journey-prompt__input"
-                      value={draftAnswer}
-                      placeholder={
-                        activeStep.placeholder ?? 'ここに感じたことをメモ'
-                      }
-                      onChange={(event) =>
-                        handleAnswerChange(event.currentTarget.value)
-                      }
-                      disabled={Boolean(storedResponse && !isEditing)}
-                      rows={3}
+                <span className="journey-memory-intro__title">
+                  {activeJourney.title}
+                </span>
+                <span className="journey-memory-intro__hint">
+                  タップで思い出をひらく
+                </span>
+              </button>
+            ) : (
+              <article className="journey-card journey-card--memory">
+                {memoryStep.episode.photo?.src ? (
+                  <div
+                    className="journey-card__media"
+                    style={{
+                      background: getArtBackground(memoryStep.episode.artKey),
+                    }}
+                  >
+                    <img
+                      className="journey-card__photo"
+                      src={memoryStep.episode.photo.src}
+                      alt={memoryStep.episode.photo.alt}
+                      loading="lazy"
+                      style={{
+                        objectPosition:
+                          memoryStep.episode.photo.objectPosition ?? 'center',
+                      }}
                     />
-                    <div className="journey-prompt__footer">
-                      <span className="journey-prompt__status">
-                        {storedResponse?.recordedAt
-                          ? `記録: ${formatRecordedAt(
-                              storedResponse.recordedAt
-                            )}`
-                          : '未記録'}
+                    <span className="journey-card__badge">
+                      <span className="journey-card__badge-icon" aria-hidden="true">
+                        📖
                       </span>
-                      {storedResponse ? (
-                        <button
-                          type="button"
-                          className="journey-prompt__toggle"
-                          onClick={handleToggleEditing}
-                        >
-                          {isEditing ? '閲覧モードに戻す' : '編集する'}
-                        </button>
-                      ) : null}
+                      MEMORY
+                    </span>
+                  </div>
+                ) : null}
+                <div className="journey-card__body">
+                  <div className="journey-card__meta">
+                    <span className="journey-status journey-status--arrived">
+                      MEMORY
+                    </span>
+                    <span className="journey-card__date">
+                      {formatJourneyDate(activeJourney.date)}
+                    </span>
+                  </div>
+                  <span className="journey-memory__journey">{activeJourney.title}</span>
+                  {memoryStep.episode.title ? (
+                    <h3 className="journey-card__episode-title">
+                      {memoryStep.episode.title}
+                    </h3>
+                  ) : null}
+                  <div className="journey-card__text-group">
+                    {memoryStep.episode.text
+                      .filter((paragraph) => paragraph.trim().length > 0)
+                      .map((paragraph, index) => (
+                        <p key={index} className="journey-card__caption">
+                          {paragraph}
+                        </p>
+                      ))}
+                  </div>
+                  {memoryStep.questions.length ? (
+                    <div className="journey-memory__questions">
+                      <h4 className="journey-memory__questions-title">
+                        記録ノート
+                      </h4>
+                      <div className="journey-prompts">
+                        {memoryStep.questions.map((question) => {
+                          const stored = responseMap.get(question.storageKey)
+                          const draft = draftAnswers[question.id] ?? ''
+                          const isLocked =
+                            question.readonlyAfterSave !== false && Boolean(stored)
+
+                          const handleChoiceSelect = (choice: string) => {
+                            if (isLocked) {
+                              return
+                            }
+                            handleQuestionDraftChange(question.id, choice)
+                          }
+
+                          const handleInputChange = (
+                            value: string
+                          ) => {
+                            if (isLocked) {
+                              return
+                            }
+                            handleQuestionDraftChange(question.id, value)
+                          }
+
+                          const handleSaveClick = () => {
+                            if (isLocked) {
+                              return
+                            }
+                            handleQuestionSave(question)
+                          }
+
+                          const canSave = !isLocked && draft.trim().length > 0
+
+                          return (
+                            <div
+                              key={question.id}
+                              className="journey-prompt"
+                              role="group"
+                              aria-labelledby={`${question.id}-prompt`}
+                            >
+                              <span
+                                id={`${question.id}-prompt`}
+                                className="journey-prompt__question"
+                              >
+                                {question.prompt}
+                              </span>
+                              {question.helper ? (
+                                <span className="journey-prompt__helper">
+                                  {question.helper}
+                                </span>
+                              ) : null}
+                              {question.style === 'choice' ? (
+                                <div className="journey-prompt__choices">
+                                  {(question.choices ?? []).map((choice) => {
+                                    const isSelected = draft === choice
+                                    return (
+                                      <button
+                                        key={choice}
+                                        type="button"
+                                        className={`journey-choice${
+                                          isSelected ? ' is-selected' : ''
+                                        }${isLocked ? ' is-locked' : ''}`}
+                                        onClick={() => handleChoiceSelect(choice)}
+                                        disabled={isLocked}
+                                      >
+                                        <span
+                                          className="journey-choice__icon"
+                                          aria-hidden="true"
+                                        >
+                                          {isSelected ? '●' : '○'}
+                                        </span>
+                                        <span className="journey-choice__label">
+                                          {choice}
+                                        </span>
+                                      </button>
+                                    )
+                                  })}
+                                </div>
+                              ) : (
+                                <textarea
+                                  id={question.id}
+                                  className="journey-prompt__input"
+                                  value={draft}
+                                  placeholder={
+                                    question.placeholder ?? 'ここに感じたことをメモ'
+                                  }
+                                  onChange={(event) =>
+                                    handleInputChange(event.currentTarget.value)
+                                  }
+                                  disabled={isLocked}
+                                  rows={4}
+                                />
+                              )}
+                              <div className="journey-prompt__footer">
+                                <span className="journey-prompt__status">
+                                  {stored?.recordedAt
+                                    ? `記録: ${formatRecordedAt(
+                                        stored.recordedAt
+                                      )}`
+                                    : '未記録'}
+                                </span>
+                                <div className="journey-prompt__actions">
+                                  {isLocked ? (
+                                    <span className="journey-prompts__locked">
+                                      保存済みのため編集できません。
+                                    </span>
+                                  ) : (
+                                    <button
+                                      type="button"
+                                      className="journey-prompt__save"
+                                      onClick={handleSaveClick}
+                                      disabled={!canSave}
+                                    >
+                                      記録する
+                                    </button>
+                                  )}
+                                </div>
+                              </div>
+                            </div>
+                          )
+                        })}
+                      </div>
                     </div>
-                  </label>
+                  ) : null}
                 </div>
-              </div>
-            </article>
+              </article>
+            )
           ) : null}
         </div>
 
@@ -700,7 +1034,7 @@ export const JourneysScene = ({
             onClick={handlePrevStep}
             disabled={prevDisabled}
           >
-            前のステップ
+            前のページ
           </button>
           <button
             type="button"
@@ -715,3 +1049,4 @@ export const JourneysScene = ({
     </SceneLayout>
   )
 }
+

--- a/src/types/experience.ts
+++ b/src/types/experience.ts
@@ -1,6 +1,7 @@
 export interface SaveJourneyResponsePayload {
   journeyId: string
   stepId: string
+  storageKey: string
   prompt: string
   answer: string
 }

--- a/src/types/journey.ts
+++ b/src/types/journey.ts
@@ -1,15 +1,32 @@
-export type TransportMode = 'plane' | 'bus' | 'train'
+export type JourneyMoveMode = 'flight' | 'walk' | 'bus' | 'train'
+
+export type JourneyCoordinate = [number, number]
+
+export interface JourneyMoveMeta {
+  flightNo?: string
+  dep?: string
+  arr?: string
+  note?: string
+}
 
 export interface JourneyMoveStep {
   id: string
   type: 'move'
+  mode: JourneyMoveMode
   from: string
   to: string
-  transport: TransportMode
   /** 距離HUDに反映する移動距離（km）。 */
   distanceKm: number
   /** メディアアート背景のキー。 */
-  artKey: string
+  artKey?: string
+  /** 画面上の開始地点の座標（0〜100の正規化値）。 */
+  fromCoord?: JourneyCoordinate
+  /** 画面上の到着地点の座標（0〜100の正規化値）。 */
+  toCoord?: JourneyCoordinate
+  /** 抽象マップ上のルート。 */
+  route?: JourneyCoordinate[]
+  /** フライト番号や発着時間などの補足情報。 */
+  meta?: JourneyMoveMeta
   /** ステップ固有のラベルや補足文。 */
   description?: string
 }
@@ -17,22 +34,28 @@ export interface JourneyMoveStep {
 export interface JourneyEpisodeStep {
   id: string
   type: 'episode'
-  title: string
-  caption: string
-  artKey: string
-  media: {
+  title?: string
+  text: string[]
+  artKey?: string
+  photo: {
     src: string
     alt: string
     objectPosition?: string
   }
 }
 
+export type JourneyQuestionStyle = 'choice' | 'text'
+
 export interface JourneyQuestionStep {
   id: string
   type: 'question'
+  style: JourneyQuestionStyle
   prompt: string
+  storageKey: string
+  choices?: string[]
   placeholder?: string
   helper?: string
+  readonlyAfterSave?: boolean
 }
 
 export type JourneyStep =


### PR DESCRIPTION
## Summary
- allow the journeys scene to scroll so navigation stays reachable on mobile
- rework the journeys renderer to alternate move and memory pages with tap-to-reveal title cards and embedded questions
- add memory-specific styling and save actions so responses lock after being recorded while the HUD now shows only total distance
- externalize the journeys dataset to JSON while keeping distance totals derived when loading

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf1c59854c832fab82f8b1063a8efc