### PR TITLE
Replace AI merge workflow with stable version

### DIFF
--- a/.github/workflows/ai-merge.yml
+++ b/.github/workflows/ai-merge.yml
@@ -1,47 +1,83 @@
-name: AI Merge & Automerge (no API key)
+name: AI Merge & Automerge (stable)
 
 on:
   pull_request:
     types: [labeled, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: 'Pull request number to resolve'
+        required: true
 
 permissions:
   contents: write
   pull-requests: write
-  models: read   # ← GitHub Models を呼ぶのに必要
+  models: read
 
 jobs:
   ai-merge:
-    if: >
-      (github.event.action == 'labeled' && github.event.label.name == 'ai-resolve') ||
-      contains(github.event.pull_request.labels.*.name, 'ai-resolve')
-    if: contains(github.event.pull_request.labels.*.name, 'ai-resolve')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && ((github.event.action == 'labeled' && github.event.label.name == 'ai-resolve') || contains(github.event.pull_request.labels.*.name, 'ai-resolve')))
     runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pull_request_number || '' }}
+      BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+      REPO: ${{ github.repository }}
+      EVENT_NAME: ${{ github.event_name }}
+      SHOULD_CONTINUE: 'true'
+
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
-        with: { node-version: '20' }
+        with:
+          node-version: '20'
 
       - name: Resolve conflicts with GitHub Models (LLM)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # ← これだけでOK
-          BASE: ${{ github.event.pull_request.base.ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          # 1) ベースを取り込んで競合を発生させる（PRヘッドに対してベースをマージ）
-          git fetch origin "$BASE"
-          if git merge --no-commit --no-ff "origin/$BASE"; then
+
+          PR="${PR_NUMBER}"
+          if [ -z "$PR" ]; then
+            echo "Pull request number is required."
+            exit 1
+          fi
+
+          BASE_BRANCH="${BASE_REF}"
+
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            LABELS=$(gh pr view "$PR" --repo "${REPO}" --json labels -q '.labels[].name')
+            if ! grep -Fxq 'ai-resolve' <<<"$LABELS"; then
+              echo "PR #$PR does not have the ai-resolve label. Exiting."
+              echo "SHOULD_CONTINUE=false" >> "$GITHUB_ENV"
+              exit 0
+            fi
+            if [ -z "$BASE_BRANCH" ]; then
+              BASE_BRANCH=$(gh pr view "$PR" --repo "${REPO}" --json baseRefName -q .baseRefName)
+            fi
+          fi
+
+          if [ -z "$BASE_BRANCH" ]; then
+            BASE_BRANCH=$(gh pr view "$PR" --repo "${REPO}" --json baseRefName -q .baseRefName)
+          fi
+
+          BASE_BRANCH=$(echo "$BASE_BRANCH" | tr -d '\r')
+          echo "Using base branch $BASE_BRANCH"
+
+          git fetch origin "$BASE_BRANCH"
+          if git merge --no-commit --no-ff "origin/$BASE_BRANCH"; then
             echo "No conflicts. Nothing to do."
             exit 0
           fi
 
-          # 2) 競合ファイル一覧
           CONFLICTS=$(git diff --name-only --diff-filter=U)
           echo "Conflicted files:"
           echo "$CONFLICTS"
 
-          # 3) 各ファイルを戦略分岐して解決
           node - <<'NODE'
           import { execSync } from "node:child_process";
           import fs from "node:fs";
@@ -49,15 +85,14 @@ jobs:
           const GHTOKEN = process.env.GITHUB_TOKEN;
           const conflicts = execSync("git diff --name-only --diff-filter=U").toString().trim().split("\n").filter(Boolean);
 
-          // 戦略：生成物＆ロックは片側優先、ドキュメントは両取り、コードはLLM
-          const ALWAYS_THEIRS = [/^dist\//, /^build\//, \.min\./, /^package-lock\.json$/, /^yarn\.lock$/, /^pnpm-lock\.yaml$/];
-          const UNION = [/\.md$/, /\.svg$/, /\.ya?ml$/];
+          const ALWAYS_THEIRS = [/^dist\//, /^build\//, /\.min\./, /^package-lock\.json$/, /^yarn\.lock$/, /^pnpm-lock\.yaml$/];
+          const UNION = [/\.md$/, /\.svg$/, /\.ya?ml$/, /\.json$/];
 
           const pick = (p)=>ALWAYS_THEIRS.some(r=>r.test(p))?"theirs":UNION.some(r=>r.test(p))?"union":"ai";
 
           const show = (spec, file) => {
             try { return execSync(`git show ${spec}:${file}`, {stdio:['ignore','pipe','pipe']}).toString(); }
-            catch { return ""; } // base(:1:)は無いこともある
+            catch { return ""; }
           }
 
           const callModel = async (model, messages) => {
@@ -67,12 +102,7 @@ jobs:
                 "Content-Type":"application/json",
                 "Authorization":`Bearer ${GHTOKEN}`
               },
-              body: JSON.stringify({
-                model,
-                temperature: 0.1,
-                messages,
-                max_tokens: 8000
-              })
+              body: JSON.stringify({ model, temperature: 0.1, messages, max_tokens: 8000 })
             });
             if (!res.ok) throw new Error(`Model HTTP ${res.status}`);
             const j = await res.json();
@@ -84,62 +114,37 @@ jobs:
             const ours = show(":2", file);
             const theirs = show(":3", file);
 
-            const system = "You merge two conflicting versions of ONE file. Keep buildable, deduplicate imports, keep both intentional changes. Output ONLY the final file, no fences, no commentary.";
-            const user = `FILE: ${file}
-BASE (may be empty):
-${base}
+            const system = "You merge two conflicting versions of ONE file. Keep buildable, deduplicate imports, keep both intentional changes. Output ONLY the final file.";
+            const user = `FILE: ${file}\nBASE:\n${base}\nHEAD:\n${ours}\nINCOMING:\n${theirs}`;
 
-HEAD (ours):
-${ours}
-
-INCOMING (theirs):
-${theirs}
-
-Return the merged file content only.`;
-
-            // まず軽量モデル
             try {
               const merged = await callModel("openai/gpt-4o-mini", [
                 {role:"system", content: system},
                 {role:"user", content: user}
               ]);
               if (merged && merged.trim().length>0) return merged;
-            } catch(e) {
-              // あとでフォールバック
-            }
-            // ダメなら両取り(マーカー除去)にフォールバック
+            } catch(e) {}
+
             const withMarkers = fs.readFileSync(file,"utf8");
-            return withMarkers
-              .replace(/^<<<<<<<[^\n]*\n/gm,"")
-              .replace(/^\={7,}\n/gm,"")
-              .replace(/^>>>>>>>[^\n]*\n/gm,"");
+            return withMarkers.replace(/^<<<<<<<[^\n]*\n/gm,"").replace(/^\={7,}\n/gm,"").replace(/^>>>>>>>[^\n]*\n/gm,"");
           };
 
           const main = async ()=>{
             for (const f of conflicts) {
               const s = pick(f);
               console.log(`Resolving ${f} [${s}]`);
-              if (s === "theirs") {
-                execSync(`git checkout --theirs -- "${f}"`);
-                continue;
-              }
+              if (s === "theirs") { execSync(`git checkout --theirs -- "${f}"`); continue; }
               if (s === "union") {
-                const txt = fs.readFileSync(f,"utf8")
-                  .replace(/^<<<<<<<[^\n]*\n/gm,"")
-                  .replace(/^\={7,}\n/gm,"")
-                  .replace(/^>>>>>>>[^\n]*\n/gm,"");
-                fs.writeFileSync(f, txt);
-                continue;
+                const txt = fs.readFileSync(f,"utf8").replace(/^<<<<<<<[^\n]*\n/gm,"").replace(/^\={7,}\n/gm,"").replace(/^>>>>>>>[^\n]*\n/gm,"");
+                fs.writeFileSync(f, txt); continue;
               }
               const merged = await aiMerge(f);
               fs.writeFileSync(f, merged);
             }
           };
           await main();
-
           NODE
 
-          # 4) マージ継続（残ってたら最終的にマーカー除去）
           if ! git -c core.editor=true merge --continue; then
             for f in $CONFLICTS; do
               sed -i -e '/^<<<<<<< /d' -e '/^=======/d' -e '/^>>>>>>> /d' "$f" || true
@@ -147,14 +152,12 @@ Return the merged file content only.`;
             git -c core.editor=true merge --continue || true
           fi
 
-          # 5) 依存インストール＆軽いテスト（あるなら）
           if [ -f package.json ]; then
             npm ci || npm i
             npm test || true
             npm run build || true
           fi
 
-          # 6) 変更があればプッシュ
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name  "ai-merge-bot"
             git config user.email "actions@users.noreply.github.com"
@@ -164,5 +167,7 @@ Return the merged file content only.`;
           fi
 
       - name: Enable auto-merge if clean
-        run: |
-          gh pr merge ${{ github.event.pull_request.number }} --merge --auto || true
+        if: env.PR_NUMBER != '' && env.SHOULD_CONTINUE == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge "$PR_NUMBER" --repo "$REPO" --merge --auto || true


### PR DESCRIPTION
## Summary
- replace the ai-merge workflow with the updated stable configuration
- add manual dispatch inputs and repository context so only ai-resolve labeled PRs execute
- fix the `.min.` asset regex and guard auto-merge with the resolved PR number

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf486e9c50832f97673c3b36a2ba4f