### PR TITLE
Refactor journeys scene into alternating storybook

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -94,7 +94,13 @@
 .scene-container {
   flex: 1;
   display: flex;
-  padding: calc(env(safe-area-inset-top, 0px) + 1.75rem) 1.5rem calc(env(safe-area-inset-bottom, 0px) + 2.25rem);
+  padding: calc(env(safe-area-inset-top, 0px) + 1.75rem) 1.5rem calc(
+      env(safe-area-inset-bottom, 0px) + 2.25rem
+    );
+  overflow-y: auto;
+  min-height: 0;
+  width: 100%;
+  -webkit-overflow-scrolling: touch;
 }
 
 .scene-footer {
@@ -370,15 +376,6 @@
 .distance-hud__value {
   font-weight: 600;
   font-size: 0.95rem;
-}
-
-.distance-hud__goal {
-  display: inline-block;
-  margin-left: 0.4rem;
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(245, 244, 255, 0.7);
 }
 
 .result-grid {
@@ -811,7 +808,7 @@
   font-weight: 500;
 }
 
-.journeys-header__mode {
+.journeys-header__chip {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -825,8 +822,23 @@
   color: rgba(245, 244, 255, 0.82);
 }
 
-.journeys-header__mode span:first-child {
+.journeys-header__chip span:first-child {
   font-size: 1rem;
+}
+
+.journeys-header__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: rgba(245, 244, 255, 0.9);
+}
+
+.journeys-header__description {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: rgba(245, 244, 255, 0.75);
 }
 
 .journeys-progress-bar {
@@ -886,6 +898,126 @@
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+}
+
+.journeys-stage--storybook {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .journeys-stage--storybook {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.journey-page {
+  position: relative;
+  display: flex;
+  min-height: 100%;
+}
+
+.journey-page .journey-card {
+  width: 100%;
+  transition: transform 0.35s ease, opacity 0.35s ease, box-shadow 0.35s ease,
+    border-color 0.35s ease;
+}
+
+.journey-page.is-active .journey-card {
+  transform: translateY(-6px);
+  border-color: rgba(255, 102, 196, 0.4);
+  box-shadow: 0 24px 50px rgba(9, 12, 40, 0.5);
+}
+
+.journey-page.is-dimmed .journey-card {
+  opacity: 0.7;
+  filter: saturate(0.85);
+}
+
+.journey-page.is-empty {
+  border-radius: 1.5rem;
+  border: 1px dashed rgba(163, 174, 255, 0.35);
+  background: rgba(12, 16, 48, 0.5);
+  color: rgba(245, 244, 255, 0.65);
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1.5rem;
+  min-height: 320px;
+  font-size: 0.92rem;
+  letter-spacing: 0.08em;
+}
+
+.journey-page__placeholder {
+  max-width: 240px;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .journey-page.is-empty {
+    min-height: 240px;
+  }
+}
+
+.journey-route {
+  position: relative;
+  border-radius: 1.25rem;
+  margin: 1rem 0;
+  padding: 0.75rem;
+  background: linear-gradient(145deg, rgba(19, 24, 62, 0.88), rgba(9, 12, 40, 0.95));
+  border: 1px solid rgba(163, 174, 255, 0.18);
+  overflow: hidden;
+}
+
+.journey-route::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+      circle at 18% 30%,
+      rgba(255, 102, 196, 0.15),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 78% 72%,
+      rgba(77, 123, 255, 0.18),
+      transparent 52%
+    );
+  opacity: 0.7;
+}
+
+.journey-route svg {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  aspect-ratio: 5 / 3;
+  display: block;
+}
+
+.journey-route__track {
+  fill: none;
+  stroke: rgba(163, 174, 255, 0.24);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.journey-route__path {
+  fill: none;
+  stroke-width: 2.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.journey-route__node {
+  fill: #f5f4ff;
+  stroke: rgba(15, 20, 56, 0.7);
+  stroke-width: 1.3;
+}
+
+.journey-route__node--end {
+  fill: #ffb2e2;
 }
 
 .journey-map {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,10 +102,7 @@ function App() {
   return (
     <div className={`app-shell scene-${currentSceneId}`}>
       {currentSceneId !== 'intro' && <GlobalStarfield />}
-      <DistanceHUD
-        distanceKm={distanceTraveled}
-        goalKm={totalJourneyDistance}
-      />
+      <DistanceHUD distanceKm={distanceTraveled} />
       <main className="scene-container">
         {renderScene(currentSceneId, sceneProps)}
       </main>

--- a/src/components/DistanceHUD.tsx
+++ b/src/components/DistanceHUD.tsx
@@ -1,6 +1,5 @@
 interface DistanceHUDProps {
   distanceKm: number
-  goalKm?: number
 }
 
 const formatDistance = (distanceKm: number) =>
@@ -8,17 +7,11 @@ const formatDistance = (distanceKm: number) =>
     maximumFractionDigits: 0,
   }).format(Math.round(distanceKm))
 
-export const DistanceHUD = ({ distanceKm, goalKm }: DistanceHUDProps) => {
-  const hasGoal = typeof goalKm === 'number'
+export const DistanceHUD = ({ distanceKm }: DistanceHUDProps) => {
   return (
     <div className="distance-hud" aria-live="polite">
       <span className="distance-hud__label">TOTAL DISTANCE</span>
-      <span className="distance-hud__value">
-        {formatDistance(distanceKm)} km
-        {hasGoal ? (
-          <span className="distance-hud__goal"> / {formatDistance(goalKm!)} km</span>
-        ) : null}
-      </span>
+      <span className="distance-hud__value">{formatDistance(distanceKm)} km</span>
     </div>
   )
 }

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -2,13 +2,10 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
-  type CSSProperties,
 } from 'react'
 
 import { SceneLayout } from '../components/SceneLayout'
-import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import type {
   Journey,
   JourneyEpisodeStep,
@@ -19,9 +16,6 @@ import type {
   JourneyCoordinate,
 } from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
-
-const PLANE_ANIMATION_MS = 1600
-const COMPLETION_EPSILON = 0.5
 
 const distanceFormatter = new Intl.NumberFormat('ja-JP', {
   maximumFractionDigits: 0,
@@ -94,48 +88,6 @@ const stepTypeLabel: Record<JourneyStep['type'], string> = {
   question: '記録',
 }
 
-type MoveMeta = {
-  stepId: string
-  journeyId: string
-  distanceKm: number
-  cumulativeBefore: number
-  cumulativeAfter: number
-}
-
-const buildMoveMetas = (journeyList: Journey[]): MoveMeta[] => {
-  const result: MoveMeta[] = []
-  let running = 0
-
-  journeyList.forEach((journey) => {
-    journey.steps.forEach((step) => {
-      if (step.type === 'move') {
-        const before = running
-        running += step.distanceKm
-        result.push({
-          stepId: step.id,
-          journeyId: journey.id,
-          distanceKm: step.distanceKm,
-          cumulativeBefore: before,
-          cumulativeAfter: running,
-        })
-      }
-    })
-  })
-
-  return result
-}
-
-const isMoveStep = (step: JourneyStep | undefined): step is JourneyMoveStep =>
-  step?.type === 'move'
-
-const isEpisodeStep = (
-  step: JourneyStep | undefined
-): step is JourneyEpisodeStep => step?.type === 'episode'
-
-const isQuestionStep = (
-  step: JourneyStep | undefined
-): step is JourneyQuestionStep => step?.type === 'question'
-
 const defaultRoute: JourneyCoordinate[] = [
   [12, 78],
   [28, 66],
@@ -168,51 +120,391 @@ const toRoutePath = (points: JourneyCoordinate[]): string => {
   )
 }
 
+type StepEntry = {
+  journey: Journey
+  step: JourneyStep
+  journeyIndex: number
+  stepIndex: number
+  globalIndex: number
+}
+
+const buildStepEntries = (journeyList: Journey[]): StepEntry[] => {
+  const entries: StepEntry[] = []
+
+  journeyList.forEach((journey, journeyIndex) => {
+    journey.steps.forEach((step, stepIndex) => {
+      entries.push({
+        journey,
+        step,
+        journeyIndex,
+        stepIndex,
+        globalIndex: entries.length,
+      })
+    })
+  })
+
+  return entries
+}
+
+const isMoveStep = (step: JourneyStep | undefined): step is JourneyMoveStep =>
+  step?.type === 'move'
+
+const isEpisodeStep = (
+  step: JourneyStep | undefined
+): step is JourneyEpisodeStep => step?.type === 'episode'
+
+const isQuestionStep = (
+  step: JourneyStep | undefined
+): step is JourneyQuestionStep => step?.type === 'question'
+
+const findLatestEntry = (
+  entries: StepEntry[],
+  maxIndex: number,
+  matcher: (step: JourneyStep) => boolean
+): StepEntry | undefined => {
+  for (let index = Math.min(maxIndex, entries.length - 1); index >= 0; index -= 1) {
+    const entry = entries[index]
+    if (entry && matcher(entry.step)) {
+      return entry
+    }
+  }
+
+  return undefined
+}
+
+const computeTraveledDistance = (
+  journeyList: Journey[],
+  activeJourneyIndex: number,
+  activeStepIndex: number
+) => {
+  let sum = 0
+
+  journeyList.forEach((journey, journeyIndex) => {
+    journey.steps.forEach((step, stepIndex) => {
+      if (step.type !== 'move') {
+        return
+      }
+
+      const isBeforeActiveJourney = journeyIndex < activeJourneyIndex
+      const isSameJourney = journeyIndex === activeJourneyIndex
+      const isBeforeOrEqualStep = stepIndex <= activeStepIndex
+
+      if (isBeforeActiveJourney || (isSameJourney && isBeforeOrEqualStep)) {
+        sum += step.distanceKm
+      }
+    })
+  })
+
+  return sum
+}
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max)
+
+const createFlightRoutePath = (
+  from: JourneyCoordinate,
+  to: JourneyCoordinate
+): string => {
+  const [x1, y1] = from
+  const [x2, y2] = to
+  const midX = (x1 + x2) / 2
+  const distance = Math.hypot(x2 - x1, y2 - y1)
+  const arcHeight = clamp(Math.min(y1, y2) - distance * 0.18, 5, 95)
+
+  return `M ${x1} ${y1} Q ${midX} ${arcHeight} ${x2} ${y2}`
+}
+
+const JourneyRouteMap = ({ step }: { step: JourneyMoveStep }) => {
+  const points =
+    step.mode === 'flight' && step.fromCoord && step.toCoord
+      ? [step.fromCoord, step.toCoord]
+      : getRoutePoints(step)
+
+  const pathData =
+    step.mode === 'flight' && step.fromCoord && step.toCoord
+      ? createFlightRoutePath(step.fromCoord, step.toCoord)
+      : toRoutePath(points)
+
+  const gradientId = `journey-route-gradient-${step.id}`
+
+  return (
+    <div className={`journey-route journey-route--${step.mode}`} aria-hidden="true">
+      <svg viewBox="0 0 100 100" role="presentation" focusable="false">
+        <defs>
+          <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stopColor="#ff66c4" />
+            <stop offset="100%" stopColor="#4d7bff" />
+          </linearGradient>
+        </defs>
+        {pathData ? (
+          <>
+            <path className="journey-route__track" d={pathData} />
+            <path
+              className="journey-route__path"
+              d={pathData}
+              stroke={`url(#${gradientId})`}
+            />
+          </>
+        ) : null}
+        {points.map((point, index) => (
+          <circle
+            key={`${point[0]}-${point[1]}-${index}`}
+            className={`journey-route__node${
+              index === points.length - 1 ? ' journey-route__node--end' : ''
+            }`}
+            cx={point[0]}
+            cy={point[1]}
+            r={index === 0 || index === points.length - 1 ? 2.8 : 1.6}
+          />
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+const JourneyMovePage = ({
+  step,
+  journey,
+}: {
+  step: JourneyMoveStep
+  journey: Journey
+}) => {
+  const transport = transportMeta[step.mode]
+
+  return (
+    <article className="journey-card journey-card--move">
+      <div className="journey-card__body">
+        <div className="journey-card__meta">
+          <span className="journey-status journey-status--arrived">MOVE</span>
+          <span className="journey-card__date">{formatJourneyDate(journey.date)}</span>
+        </div>
+        <div className="journey-card__route">
+          <span className="journey-card__city">{step.from}</span>
+          <span className="journey-card__arrow" aria-hidden="true">
+            →
+          </span>
+          <span className="journey-card__city">{step.to}</span>
+        </div>
+        <JourneyRouteMap step={step} />
+        <div className="journey-card__transport">
+          <span aria-hidden="true">{transport?.icon ?? '•'}</span>
+          <span>{transport?.label ?? step.mode.toUpperCase()}</span>
+          <span>{formatDistance(step.distanceKm)} km</span>
+        </div>
+        {step.description ? (
+          <p className="journey-card__caption">{step.description}</p>
+        ) : null}
+        {step.meta ? (
+          <dl className="journey-card__meta-grid">
+            {step.meta.flightNo ? (
+              <div>
+                <dt>便名</dt>
+                <dd>{step.meta.flightNo}</dd>
+              </div>
+            ) : null}
+            {step.meta.dep ? (
+              <div>
+                <dt>出発</dt>
+                <dd>{step.meta.dep}</dd>
+              </div>
+            ) : null}
+            {step.meta.arr ? (
+              <div>
+                <dt>到着</dt>
+                <dd>{step.meta.arr}</dd>
+              </div>
+            ) : null}
+            {step.meta.note ? (
+              <div className="journey-card__meta-note">
+                <dt>NOTE</dt>
+                <dd>{step.meta.note}</dd>
+              </div>
+            ) : null}
+          </dl>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+const JourneyEpisodePage = ({
+  step,
+  journey,
+}: {
+  step: JourneyEpisodeStep
+  journey: Journey
+}) => {
+  return (
+    <article className="journey-card journey-card--episode">
+      <div
+        className="journey-card__media"
+        style={{ background: getArtBackground(step.artKey) }}
+      >
+        <img
+          className="journey-card__photo"
+          src={step.photo.src}
+          alt={step.photo.alt}
+          loading="lazy"
+          style={
+            step.photo.objectPosition
+              ? { objectPosition: step.photo.objectPosition }
+              : undefined
+          }
+        />
+        <span className="journey-card__badge">
+          <span className="journey-card__badge-icon" aria-hidden="true">
+            ✨
+          </span>
+          MEMORIES
+        </span>
+      </div>
+      <div className="journey-card__body">
+        <div className="journey-card__meta">
+          <span className="journey-status journey-status--arrived">EPISODE</span>
+          <span className="journey-card__date">{formatJourneyDate(journey.date)}</span>
+        </div>
+        {step.title ? (
+          <h3 className="journey-card__episode-title">{step.title}</h3>
+        ) : null}
+        <div className="journey-card__text-group">
+          {step.text.map((paragraph, index) => (
+            <p key={index} className="journey-card__caption">
+              {paragraph}
+            </p>
+          ))}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+const JourneyQuestionPage = ({
+  step,
+  journey,
+  value,
+  storedResponse,
+  isActive,
+  isLocked,
+  onAnswerChange,
+  onTextBlur,
+}: {
+  step: JourneyQuestionStep
+  journey: Journey
+  value: string
+  storedResponse?: SceneComponentProps['responses'][number]
+  isActive: boolean
+  isLocked: boolean
+  onAnswerChange?: (value: string) => void
+  onTextBlur?: () => void
+}) => {
+  const isChoice = step.style === 'choice'
+  const recordedLabel = storedResponse?.recordedAt
+    ? `記録: ${formatRecordedAt(storedResponse.recordedAt)}`
+    : '未記録'
+
+  const lockMessage = !isActive
+    ? storedResponse
+      ? '保存済みの記録です。'
+      : '移動ページで進めると回答できます。'
+    : isLocked
+      ? '保存済みのため編集できません。'
+      : null
+
+  return (
+    <article className="journey-card journey-card--question">
+      <div className="journey-card__body">
+        <div className="journey-card__meta">
+          <span className="journey-status journey-status--arrived">
+            {isChoice ? 'QUIZ' : 'NOTE'}
+          </span>
+          <span className="journey-card__date">{formatJourneyDate(journey.date)}</span>
+        </div>
+        <div className="journey-prompts journey-prompts--single">
+          <div className="journey-prompt" role="group">
+            <span className="journey-prompt__question">{step.prompt}</span>
+            {step.helper ? (
+              <span className="journey-prompt__helper">{step.helper}</span>
+            ) : null}
+            {isChoice ? (
+              <div className="journey-prompt__choices">
+                {(step.choices ?? []).map((choice) => {
+                  const isSelected = value === choice
+                  const disabled = isLocked || !isActive
+                  return (
+                    <button
+                      key={choice}
+                      type="button"
+                      className={`journey-choice${
+                        isSelected ? ' is-selected' : ''
+                      }${disabled ? ' is-locked' : ''}`}
+                      onClick={
+                        disabled || !onAnswerChange
+                          ? undefined
+                          : () => onAnswerChange(choice)
+                      }
+                      disabled={disabled}
+                    >
+                      <span className="journey-choice__icon" aria-hidden="true">
+                        {isSelected ? '●' : '○'}
+                      </span>
+                      <span className="journey-choice__label">{choice}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            ) : (
+              <textarea
+                id={step.id}
+                className="journey-prompt__input"
+                value={value}
+                placeholder={step.placeholder ?? 'ここに感じたことをメモ'}
+                onChange={
+                  !isLocked && isActive && onAnswerChange
+                    ? (event) => onAnswerChange(event.currentTarget.value)
+                    : undefined
+                }
+                onBlur={isActive && onTextBlur ? onTextBlur : undefined}
+                disabled={isLocked || !isActive}
+                rows={3}
+              />
+            )}
+            <div className="journey-prompt__footer">
+              <span className="journey-prompt__status">{recordedLabel}</span>
+              {lockMessage ? (
+                <span className="journey-prompts__locked">{lockMessage}</span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}
+
+const JourneyPagePlaceholder = ({
+  variant,
+}: {
+  variant: 'move' | 'story'
+}) => (
+  <div className="journey-page__placeholder">
+    {variant === 'move'
+      ? '移動ステップを選ぶとルートが表示されます。'
+      : '思い出や記録のページはここに表示されます。'}
+  </div>
+)
+
 export const JourneysScene = ({
   onAdvance,
   journeys,
-  distanceTraveled,
-  totalJourneyDistance,
   responses,
   saveResponse,
   setDistanceTraveled,
 }: SceneComponentProps) => {
-  const prefersReducedMotion = usePrefersReducedMotion()
-
-  const moveMetas = useMemo(() => buildMoveMetas(journeys), [journeys])
-  const moveMetaMap = useMemo(() => {
-    const map = new Map<string, MoveMeta>()
-    moveMetas.forEach((meta) => {
-      map.set(meta.stepId, meta)
-    })
-    return map
-  }, [moveMetas])
-
-  const responseMap = useMemo(() => {
-    const map = new Map<string, typeof responses[number]>()
-    responses.forEach((entry) => {
-      map.set(entry.storageKey, entry)
-    })
-    return map
-  }, [responses])
+  const stepEntries = useMemo(() => buildStepEntries(journeys), [journeys])
 
   const [activeJourneyIndex, setActiveJourneyIndex] = useState(0)
   const [activeStepIndex, setActiveStepIndex] = useState(0)
-  const [animationState, setAnimationState] = useState<
-    'idle' | 'animating' | 'complete'
-  >('idle')
-  const animationTimeoutRef = useRef<number | null>(null)
-  const [animationToken, setAnimationToken] = useState(0)
   const [draftAnswer, setDraftAnswer] = useState('')
-
-  useEffect(
-    () => () => {
-      if (animationTimeoutRef.current !== null) {
-        window.clearTimeout(animationTimeoutRef.current)
-      }
-    },
-    []
-  )
 
   useEffect(() => {
     if (journeys.length === 0) {
@@ -242,6 +534,53 @@ export const JourneysScene = ({
   const activeJourney = journeys[activeJourneyIndex]
   const activeStep = activeJourney?.steps[activeStepIndex]
 
+  const activeEntry = useMemo(
+    () =>
+      stepEntries.find(
+        (entry) =>
+          entry.journeyIndex === activeJourneyIndex &&
+          entry.stepIndex === activeStepIndex
+      ),
+    [activeJourneyIndex, activeStepIndex, stepEntries]
+  )
+
+  const latestMoveEntry = useMemo(
+    () =>
+      activeEntry
+        ? findLatestEntry(stepEntries, activeEntry.globalIndex, (step) =>
+            step.type === 'move'
+          )
+        : undefined,
+    [activeEntry, stepEntries]
+  )
+
+  const latestStoryEntry = useMemo(
+    () =>
+      activeEntry
+        ? findLatestEntry(stepEntries, activeEntry.globalIndex, (step) =>
+            step.type !== 'move'
+          )
+        : undefined,
+    [activeEntry, stepEntries]
+  )
+
+  const traveledDistance = useMemo(
+    () => computeTraveledDistance(journeys, activeJourneyIndex, activeStepIndex),
+    [journeys, activeJourneyIndex, activeStepIndex]
+  )
+
+  useEffect(() => {
+    setDistanceTraveled(traveledDistance)
+  }, [setDistanceTraveled, traveledDistance])
+
+  const responseMap = useMemo(() => {
+    const map = new Map<string, typeof responses[number]>()
+    responses.forEach((entry) => {
+      map.set(entry.storageKey, entry)
+    })
+    return map
+  }, [responses])
+
   const questionStorageKey = isQuestionStep(activeStep)
     ? activeStep.storageKey
     : null
@@ -260,130 +599,6 @@ export const JourneysScene = ({
       setDraftAnswer('')
     }
   }, [activeStep, storedResponse])
-
-  useEffect(() => {
-    if (!isMoveStep(activeStep)) {
-      if (animationTimeoutRef.current !== null) {
-        window.clearTimeout(animationTimeoutRef.current)
-        animationTimeoutRef.current = null
-      }
-      setAnimationState('idle')
-      return
-    }
-
-    const meta = moveMetaMap.get(activeStep.id)
-    if (!meta) {
-      setAnimationState('idle')
-      return
-    }
-
-    if (distanceTraveled >= meta.cumulativeAfter - COMPLETION_EPSILON) {
-      setAnimationState('complete')
-    } else {
-      setAnimationState('idle')
-    }
-  }, [activeStep, distanceTraveled, moveMetaMap])
-
-  const completedDistance = Math.min(distanceTraveled, totalJourneyDistance)
-  const remainingDistance = Math.max(totalJourneyDistance - completedDistance, 0)
-
-  const progressPercent = totalJourneyDistance
-    ? Math.min(100, Math.max(0, (completedDistance / totalJourneyDistance) * 100))
-    : 0
-
-  const moveMeta = isMoveStep(activeStep)
-    ? moveMetaMap.get(activeStep.id)
-    : undefined
-
-  const isMoveCompleted = moveMeta
-    ? completedDistance >= moveMeta.cumulativeAfter - COMPLETION_EPSILON
-    : false
-
-  const moveState: 'idle' | 'animating' | 'complete' = animationState
-
-  const handleStartMove = () => {
-    if (!isMoveStep(activeStep) || !activeJourney) {
-      return
-    }
-
-    const meta = moveMetaMap.get(activeStep.id)
-    if (!meta) {
-      return
-    }
-
-    const finalize = () => {
-      setDistanceTraveled((current) => {
-        if (current >= meta.cumulativeAfter - COMPLETION_EPSILON) {
-          return current
-        }
-        return Math.min(meta.cumulativeAfter, totalJourneyDistance)
-      })
-      setAnimationState('complete')
-    }
-
-    if (
-      prefersReducedMotion ||
-      completedDistance >= meta.cumulativeAfter - COMPLETION_EPSILON
-    ) {
-      finalize()
-      return
-    }
-
-    setAnimationState('animating')
-    setAnimationToken((token) => token + 1)
-
-    if (animationTimeoutRef.current !== null) {
-      window.clearTimeout(animationTimeoutRef.current)
-    }
-
-    animationTimeoutRef.current = window.setTimeout(() => {
-      animationTimeoutRef.current = null
-      finalize()
-    }, PLANE_ANIMATION_MS)
-  }
-
-  const handlePrevStep = () => {
-    if (!activeJourney) {
-      return
-    }
-
-    if (activeStepIndex > 0) {
-      setActiveStepIndex((index) => Math.max(index - 1, 0))
-      return
-    }
-
-    if (activeJourneyIndex === 0) {
-      return
-    }
-
-    const nextJourneyIndex = activeJourneyIndex - 1
-    const nextJourney = journeys[nextJourneyIndex]
-    const nextStepIndex = Math.max((nextJourney?.steps.length ?? 1) - 1, 0)
-
-    setActiveJourneyIndex(nextJourneyIndex)
-    setActiveStepIndex(nextStepIndex)
-  }
-
-  const handleNextStep = () => {
-    if (!activeJourney) {
-      onAdvance()
-      return
-    }
-
-    if (activeStepIndex < activeJourney.steps.length - 1) {
-      setActiveStepIndex((index) => index + 1)
-      return
-    }
-
-    if (activeJourneyIndex >= journeys.length - 1) {
-      onAdvance()
-      return
-    }
-
-    const nextJourneyIndex = activeJourneyIndex + 1
-    setActiveJourneyIndex(nextJourneyIndex)
-    setActiveStepIndex(0)
-  }
 
   const handleAnswerChange = useCallback(
     (value: string) => {
@@ -456,53 +671,88 @@ export const JourneysScene = ({
     storedResponse,
   ])
 
-  if (!activeJourney || !activeStep) {
+  if (!activeJourney || !activeStep || !activeEntry) {
     return (
       <SceneLayout
         eyebrow="Journeys"
-        title="移動演出と思い出ギャラリー"
-        description="旅データを整備すると、ここに移動アニメーションと質問カードが並びます。"
+        title="旅の移動演出ログ"
+        description="旅データを整備すると、ここに移動ページと思い出ページが並びます。"
       >
         <p className="scene-note">
-          まだ旅のデータが登録されていません。`src/data/journeys.ts` にステップを追加してください。
+          まだ旅のデータが登録されていません。`src/data/journeys.ts` にステップを追加すると紙芝居が完成します。
         </p>
       </SceneLayout>
     )
   }
 
-  const transportStep: JourneyMoveStep | undefined = isMoveStep(activeStep)
-    ? activeStep
-    : (activeJourney.steps.find((step) => step.type === 'move') as
-        | JourneyMoveStep
-        | undefined)
+  const leftStep = isMoveStep(latestMoveEntry?.step)
+    ? latestMoveEntry.step
+    : undefined
+  const leftJourney = latestMoveEntry?.journey
+  const rightStep = latestStoryEntry?.step
+  const rightJourney = latestStoryEntry?.journey
 
-  const transport = transportStep
-    ? transportMeta[transportStep.mode]
+  const isLeftActive = isMoveStep(activeStep)
+  const isRightActive = !isLeftActive
+
+  const rightQuestionStep = isQuestionStep(rightStep) ? rightStep : undefined
+  const rightStoredResponse = rightQuestionStep
+    ? responseMap.get(rightQuestionStep.storageKey)
     : undefined
 
-  const statusLabel = (() => {
-    if (!isMoveStep(activeStep)) {
+  const rightValue = rightQuestionStep
+    ? isRightActive
+      ? draftAnswer
+      : rightStoredResponse?.answer ?? ''
+    : ''
+
+  const rightLocked = rightQuestionStep
+    ? isRightActive
+      ? isQuestionReadOnly
+      : true
+    : false
+
+  const stepCount = stepEntries.length
+  const activeStepNumber = activeEntry.globalIndex + 1
+
+  const headerSubtitle = (() => {
+    if (!activeStep) {
       return ''
     }
 
-    if (animationState === 'animating') {
-      return '移動中…'
+    if (isMoveStep(activeStep)) {
+      return `${activeStep.from} → ${activeStep.to}`
     }
 
-    if (isMoveCompleted) {
-      return '到着済み — 記録を残そう'
+    if (isEpisodeStep(activeStep)) {
+      return activeStep.title ?? activeJourney.title
     }
 
-    if (activeStep.mode === 'flight' && activeStep.meta?.flightNo) {
-      const times = [activeStep.meta.dep, activeStep.meta.arr]
-        .filter(Boolean)
-        .join(' → ')
-      return times
-        ? `${activeStep.meta.flightNo} ${times} (タップ)`
-        : `${activeStep.meta.flightNo} (タップ)`
+    if (isQuestionStep(activeStep)) {
+      return activeStep.prompt
     }
 
-    return `${activeStep.from} → ${activeStep.to} を開始 (タップ)`
+    return ''
+  })()
+
+  const headerDescription = (() => {
+    if (!activeStep) {
+      return ''
+    }
+
+    if (isMoveStep(activeStep)) {
+      return activeStep.description ?? ''
+    }
+
+    if (isEpisodeStep(activeStep)) {
+      return activeStep.text[0] ?? ''
+    }
+
+    if (isQuestionStep(activeStep)) {
+      return activeStep.helper ?? ''
+    }
+
+    return ''
   })()
 
   const isFinalJourney =
@@ -514,415 +764,140 @@ export const JourneysScene = ({
     ? 'Messagesへ進む'
     : activeStepIndex === activeJourney.steps.length - 1
       ? '次の旅へ'
-      : '次のステップ'
+      : '次のページ'
 
   const prevDisabled = activeJourneyIndex === 0 && activeStepIndex === 0
-  const nextDisabled = isMoveStep(activeStep) && !isMoveCompleted
 
-  const planeStyle: CSSProperties | undefined =
-    isMoveStep(activeStep) && activeStep.mode === 'flight'
-      ? {
-          ['--plane-from-x' as string]: `${activeStep.fromCoord?.[0] ?? 12}%`,
-          ['--plane-from-y' as string]: `${activeStep.fromCoord?.[1] ?? 50}%`,
-          ['--plane-to-x' as string]: `${activeStep.toCoord?.[0] ?? 88}%`,
-          ['--plane-to-y' as string]: `${activeStep.toCoord?.[1] ?? 50}%`,
-        }
-      : undefined
+  const handlePrevStep = () => {
+    if (!activeJourney) {
+      return
+    }
 
-  const routePoints =
-    isMoveStep(activeStep) && activeStep.mode !== 'flight'
-      ? getRoutePoints(activeStep)
-      : []
-  const routePath =
-    isMoveStep(activeStep) && activeStep.mode !== 'flight'
-      ? toRoutePath(routePoints)
-      : ''
+    if (activeStepIndex > 0) {
+      setActiveStepIndex((index) => Math.max(index - 1, 0))
+      return
+    }
 
-  const routeStart = routePoints[0]
-  const routeEnd = routePoints[routePoints.length - 1]
+    if (activeJourneyIndex === 0) {
+      return
+    }
+
+    const nextJourneyIndex = activeJourneyIndex - 1
+    const nextJourney = journeys[nextJourneyIndex]
+    const nextStepIndex = Math.max((nextJourney?.steps.length ?? 1) - 1, 0)
+
+    setActiveJourneyIndex(nextJourneyIndex)
+    setActiveStepIndex(nextStepIndex)
+  }
+
+  const handleNextStep = () => {
+    if (!activeJourney) {
+      onAdvance()
+      return
+    }
+
+    if (activeStepIndex < activeJourney.steps.length - 1) {
+      setActiveStepIndex((index) => index + 1)
+      return
+    }
+
+    if (activeJourneyIndex >= journeys.length - 1) {
+      onAdvance()
+      return
+    }
+
+    const nextJourneyIndex = activeJourneyIndex + 1
+    setActiveJourneyIndex(nextJourneyIndex)
+    setActiveStepIndex(0)
+  }
 
   return (
     <SceneLayout
       eyebrow="Journeys"
       title="旅の移動演出ログ"
-      description="この一年で実際に会いに行った旅を、移動演出とエピソード、質問で振り返ります。"
+      description="移動ページと思い出ページをめくりながら、紙芝居のように一年の旅路を振り返ろう。"
     >
       <div className="journeys-experience">
         <header className="journeys-header">
           <div className="journeys-header__row">
             <span className="journeys-header__label">
-              JOURNEY {activeJourneyIndex + 1}/{journeys.length}
+              JOURNEY {activeJourneyIndex + 1} / {journeys.length}
             </span>
-            <span className="journeys-header__distance">
-              累計 {formatDistance(completedDistance)} km
+            <span className="journeys-header__step">
+              STEP {activeStepNumber} / {stepCount}
             </span>
           </div>
           <h2 className="journeys-header__title">{activeJourney.title}</h2>
-          <p className="journeys-header__step">
-            STEP {activeStepIndex + 1}/{activeJourney.steps.length} ·{' '}
-            {stepTypeLabel[activeStep.type]}
-          </p>
           <div className="journeys-header__meta">
             <span className="journeys-header__date">
               {formatJourneyDate(activeJourney.date)}
             </span>
-            {transport ? (
-              <span className="journeys-header__mode">
-                <span aria-hidden="true">{transport.icon}</span>
-                {transport.label}
+            <span className="journeys-header__chip">
+              {stepTypeLabel[activeStep.type]}
+            </span>
+            {leftStep ? (
+              <span className="journeys-header__chip">
+                <span aria-hidden="true">{transportMeta[leftStep.mode].icon}</span>
+                {transportMeta[leftStep.mode].label}
               </span>
             ) : null}
           </div>
-          <div className="journeys-progress-bar" aria-hidden="true">
-            <div
-              className="journeys-progress-bar__fill"
-              style={{ width: `${progressPercent}%` }}
-            />
-          </div>
-          <div className="journeys-step-indicator" aria-hidden="true">
-            {activeJourney.steps.map((step, index) => {
-              const className = [
-                'journeys-step-indicator__dot',
-                index === activeStepIndex
-                  ? 'is-current'
-                  : index < activeStepIndex
-                    ? 'is-complete'
-                    : '',
-              ]
-                .filter(Boolean)
-                .join(' ')
-
-              return <span key={step.id} className={className} />
-            })}
-          </div>
-          <div className="journeys-header__secondary">
-            <span>残り {formatDistance(remainingDistance)} km</span>
-            <span>
-              {isMoveCompleted
-                ? `到着済み: ${formatDistance(
-                    moveMeta?.cumulativeAfter ?? completedDistance
-                  )} km`
-                : `出発前: ${formatDistance(
-                    moveMeta?.cumulativeBefore ?? completedDistance
-                  )} km`}
-            </span>
-          </div>
+          {headerSubtitle ? (
+            <p className="journeys-header__subtitle">{headerSubtitle}</p>
+          ) : null}
+          {headerDescription ? (
+            <p className="journeys-header__description">{headerDescription}</p>
+          ) : null}
         </header>
 
-        <div className="journeys-stage">
-          {isMoveStep(activeStep) ? (
-            <>
-              <button
-                type="button"
-                className={`journey-map${
-                  activeStep.mode !== 'flight' ? ' journey-map--route' : ''
-                }`}
-                onClick={handleStartMove}
-                disabled={animationState === 'animating'}
-                aria-live="polite"
-                aria-label={`${activeStep.from}から${activeStep.to}への移動を開始`}
-                style={{ background: getArtBackground(activeStep.artKey) }}
-              >
-                <span className="journey-map__glow" aria-hidden="true" />
-                {activeStep.mode === 'flight' ? (
-                  <div className="journey-map__line" aria-hidden="true">
-                    <span className="journey-map__line-track" />
-                    <span
-                      key={`progress-${activeStep.id}-${animationToken}-${moveState}`}
-                      className="journey-map__line-progress"
-                      data-state={moveState}
-                    />
-                  </div>
-                ) : (
-                  <div className="journey-map__route-visual" aria-hidden="true">
-                    <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
-                      <path className="journey-map__route-track" d={routePath} />
-                      <path
-                        key={`route-${activeStep.id}-${animationToken}-${moveState}`}
-                        className="journey-map__route-progress"
-                        data-state={moveState}
-                        d={routePath}
-                      />
-                      {routeStart ? (
-                        <circle
-                          className="journey-map__route-node"
-                          cx={routeStart[0]}
-                          cy={routeStart[1]}
-                          r={2.2}
-                        />
-                      ) : null}
-                      {routeEnd ? (
-                        <circle
-                          className="journey-map__route-node journey-map__route-node--end"
-                          cx={routeEnd[0]}
-                          cy={routeEnd[1]}
-                          r={2.8}
-                        />
-                      ) : null}
-                    </svg>
-                  </div>
-                )}
-                <span
-                  key={`plane-${activeStep.id}-${animationToken}-${moveState}`}
-                  className={`journey-map__plane${
-                    activeStep.mode !== 'flight'
-                      ? ' journey-map__plane--route'
-                      : ''
-                  }${
-                    prefersReducedMotion && moveState === 'complete'
-                      ? ' journey-map__plane--static'
-                      : ''
-                  }`}
-                  data-state={moveState}
-                  aria-hidden="true"
-                  style={planeStyle}
-                >
-                  {activeStep.mode === 'flight' ? (
-                    <svg viewBox="0 0 60 32" role="img" aria-hidden="true">
-                      <path
-                        d="M2 14h24l8-10h7l-7 10h18l4 2-4 2H34l7 10h-7l-8-10H2l-2-2z"
-                        fill="url(#planeGradient)"
-                      />
-                      <defs>
-                        <linearGradient
-                          id="planeGradient"
-                          x1="0%"
-                          y1="0%"
-                          x2="100%"
-                          y2="100%"
-                        >
-                          <stop offset="0%" stopColor="#ff66c4" />
-                          <stop offset="100%" stopColor="#4d7bff" />
-                        </linearGradient>
-                      </defs>
-                    </svg>
-                  ) : (
-                    <span className="journey-map__route-icon" aria-hidden="true">
-                      {transport?.icon ?? '•'}
-                    </span>
-                  )}
-                </span>
-                <div className="journey-map__labels" aria-hidden="true">
-                  <span>{activeStep.from}</span>
-                  <span>{activeStep.to}</span>
-                </div>
-                <span className="journey-map__status">{statusLabel}</span>
-              </button>
-
-              <article className="journey-card journey-card--move">
-                <div className="journey-card__body">
-                  <div className="journey-card__meta">
-                    <span
-                      className={`journey-status journey-status--${
-                        isMoveCompleted ? 'arrived' : 'pending'
-                      }`}
-                    >
-                      {isMoveCompleted ? 'ARRIVED' : 'READY'}
-                    </span>
-                    <span className="journey-card__date">
-                      {formatJourneyDate(activeJourney.date)}
-                    </span>
-                  </div>
-                  <div className="journey-card__route">
-                    <span className="journey-card__city">{activeStep.from}</span>
-                    <span className="journey-card__arrow" aria-hidden="true">
-                      →
-                    </span>
-                    <span className="journey-card__city">{activeStep.to}</span>
-                  </div>
-                  <div className="journey-card__transport">
-                    <span aria-hidden="true">{transport?.icon}</span>
-                    <span>{transport?.label}</span>
-                    <span>{formatDistance(activeStep.distanceKm)} km</span>
-                  </div>
-                  <p className="journey-card__caption">
-                    {activeStep.description ?? activeJourney.title}
-                  </p>
-                  <div className="journey-card__stats">
-                    <div>
-                      <p className="journey-card__stat-label">今回の移動距離</p>
-                      <p className="journey-card__stat-value">
-                        {formatDistance(activeStep.distanceKm)} km
-                      </p>
-                    </div>
-                    <div>
-                      <p className="journey-card__stat-label">
-                        {isMoveCompleted
-                          ? '累計距離 (到着済み)'
-                          : '累計距離 (出発前)'}
-                      </p>
-                      <p className="journey-card__stat-value">
-                        {formatDistance(
-                          isMoveCompleted
-                            ? moveMeta?.cumulativeAfter ?? completedDistance
-                            : moveMeta?.cumulativeBefore ?? completedDistance
-                        )}{' '}
-                        km
-                      </p>
-                    </div>
-                  </div>
-                  {activeStep.meta ? (
-                    <dl className="journey-card__meta-grid">
-                      {activeStep.meta.flightNo ? (
-                        <div>
-                          <dt>便名</dt>
-                          <dd>{activeStep.meta.flightNo}</dd>
-                        </div>
-                      ) : null}
-                      {activeStep.meta.dep ? (
-                        <div>
-                          <dt>出発</dt>
-                          <dd>{activeStep.meta.dep}</dd>
-                        </div>
-                      ) : null}
-                      {activeStep.meta.arr ? (
-                        <div>
-                          <dt>到着</dt>
-                          <dd>{activeStep.meta.arr}</dd>
-                        </div>
-                      ) : null}
-                      {activeStep.meta.note ? (
-                        <div className="journey-card__meta-note">
-                          <dt>NOTE</dt>
-                          <dd>{activeStep.meta.note}</dd>
-                        </div>
-                      ) : null}
-                    </dl>
-                  ) : null}
-                </div>
-              </article>
-            </>
-          ) : null}
-
-          {isEpisodeStep(activeStep) ? (
-            <article className="journey-card journey-card--episode">
-              <div
-                className="journey-card__media"
-                style={{ background: getArtBackground(activeStep.artKey) }}
-              >
-                <img
-                  className="journey-card__photo"
-                  src={activeStep.photo.src}
-                  alt={activeStep.photo.alt}
-                  loading="lazy"
-                  style={
-                    activeStep.photo.objectPosition
-                      ? { objectPosition: activeStep.photo.objectPosition }
-                      : undefined
-                  }
+        <div className="journeys-stage journeys-stage--storybook">
+          <div
+            className={[
+              'journey-page',
+              'journey-page--left',
+              leftStep ? (isLeftActive ? 'is-active' : 'is-dimmed') : 'is-empty',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {leftStep && leftJourney ? (
+              <JourneyMovePage step={leftStep} journey={leftJourney} />
+            ) : (
+              <JourneyPagePlaceholder variant="move" />
+            )}
+          </div>
+          <div
+            className={[
+              'journey-page',
+              'journey-page--right',
+              rightStep
+                ? isRightActive
+                  ? 'is-active'
+                  : 'is-dimmed'
+                : 'is-empty',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {rightStep && rightJourney ? (
+              isEpisodeStep(rightStep) ? (
+                <JourneyEpisodePage step={rightStep} journey={rightJourney} />
+              ) : isQuestionStep(rightStep) ? (
+                <JourneyQuestionPage
+                  step={rightStep}
+                  journey={rightJourney}
+                  value={rightValue}
+                  storedResponse={rightStoredResponse}
+                  isActive={isRightActive}
+                  isLocked={rightLocked}
+                  onAnswerChange={isRightActive ? handleAnswerChange : undefined}
+                  onTextBlur={isRightActive ? handleTextBlur : undefined}
                 />
-                <span className="journey-card__badge">
-                  <span className="journey-card__badge-icon" aria-hidden="true">
-                    ✨
-                  </span>
-                  MEMORIES
-                </span>
-              </div>
-              <div className="journey-card__body">
-                <div className="journey-card__meta">
-                  <span className="journey-status journey-status--arrived">
-                    EPISODE
-                  </span>
-                  <span className="journey-card__date">
-                    {formatJourneyDate(activeJourney.date)}
-                  </span>
-                </div>
-                {activeStep.title ? (
-                  <h3 className="journey-card__episode-title">
-                    {activeStep.title}
-                  </h3>
-                ) : null}
-                <div className="journey-card__text-group">
-                  {activeStep.text.map((paragraph, index) => (
-                    <p key={index} className="journey-card__caption">
-                      {paragraph}
-                    </p>
-                  ))}
-                </div>
-              </div>
-            </article>
-          ) : null}
-
-          {isQuestionStep(activeStep) ? (
-            <article className="journey-card journey-card--question">
-              <div className="journey-card__body">
-                <div className="journey-card__meta">
-                  <span className="journey-status journey-status--arrived">
-                    RECORD
-                  </span>
-                  <span className="journey-card__date">
-                    {formatJourneyDate(activeJourney.date)}
-                  </span>
-                </div>
-                <div className="journey-prompts journey-prompts--single">
-                  <div className="journey-prompt" role="group">
-                    <span className="journey-prompt__question">
-                      {activeStep.prompt}
-                    </span>
-                    {activeStep.helper ? (
-                      <span className="journey-prompt__helper">
-                        {activeStep.helper}
-                      </span>
-                    ) : null}
-                    {activeStep.style === 'choice' ? (
-                      <div className="journey-prompt__choices">
-                        {(activeStep.choices ?? []).map((choice) => {
-                          const isSelected = draftAnswer === choice
-                          return (
-                            <button
-                              key={choice}
-                              type="button"
-                              className={`journey-choice${
-                                isSelected ? ' is-selected' : ''
-                              }${
-                                isQuestionReadOnly ? ' is-locked' : ''
-                              }`}
-                              onClick={() => handleAnswerChange(choice)}
-                              disabled={isQuestionReadOnly}
-                            >
-                              <span className="journey-choice__icon" aria-hidden="true">
-                                {isSelected ? '●' : '○'}
-                              </span>
-                              <span className="journey-choice__label">{choice}</span>
-                            </button>
-                          )
-                        })}
-                      </div>
-                    ) : (
-                      <textarea
-                        id={activeStep.id}
-                        className="journey-prompt__input"
-                        value={draftAnswer}
-                        placeholder={
-                          activeStep.placeholder ?? 'ここに感じたことをメモ'
-                        }
-                        onChange={(event) =>
-                          handleAnswerChange(event.currentTarget.value)
-                        }
-                        onBlur={handleTextBlur}
-                        disabled={isQuestionReadOnly}
-                        rows={3}
-                      />
-                    )}
-                    <div className="journey-prompt__footer">
-                      <span className="journey-prompt__status">
-                        {storedResponse?.recordedAt
-                          ? `記録: ${formatRecordedAt(
-                              storedResponse.recordedAt
-                            )}`
-                          : '未記録'}
-                      </span>
-                      {isQuestionReadOnly ? (
-                        <span className="journey-prompts__locked">
-                          保存済みのため編集できません。
-                        </span>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </article>
-          ) : null}
+              ) : null
+            ) : (
+              <JourneyPagePlaceholder variant="story" />
+            )}
+          </div>
         </div>
 
         <nav className="journeys-nav" aria-label="Journeys navigation">
@@ -932,13 +907,12 @@ export const JourneysScene = ({
             onClick={handlePrevStep}
             disabled={prevDisabled}
           >
-            前のステップ
+            前のページ
           </button>
           <button
             type="button"
             className="journeys-nav__button journeys-nav__button--primary"
             onClick={handleNextStep}
-            disabled={nextDisabled}
           >
             {nextButtonLabel}
           </button>


### PR DESCRIPTION
## Summary
- allow the scene container to scroll on mobile sized screens so the layout no longer clips
- simplify the distance HUD to always show the running total without the goal comparison
- rebuild the journeys scene as an alternating move/story spread with reusable page components and a static route map

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf5c2fd644832fa793dac8634a55fc