### PR TITLE
Rebuild journeys experience with storybook stage

### DIFF
--- a/public/images/maps/travel-001-walk.svg
+++ b/public/images/maps/travel-001-walk.svg
@@ -1,0 +1,40 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">福岡空港から博多駅前ホテルまでのマップ</title>
+  <desc id="desc">夜の福岡の街並みを抽象的に描いた地図。空港から博多駅付近までの主要道路と川が描かれています。</desc>
+  <defs>
+    <linearGradient id="walk-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#10183a" />
+      <stop offset="100%" stop-color="#0a1024" />
+    </linearGradient>
+    <linearGradient id="walk-glow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(255, 110, 200, 0.25)" />
+      <stop offset="100%" stop-color="rgba(100, 160, 255, 0.22)" />
+    </linearGradient>
+    <linearGradient id="walk-river" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="rgba(48, 86, 140, 0.9)" />
+      <stop offset="100%" stop-color="rgba(20, 38, 82, 0.85)" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" fill="url(#walk-bg)" />
+  <rect width="100" height="100" fill="url(#walk-glow)" opacity="0.35" />
+  <path d="M5 65 C18 58 28 54 35 52 C44 49 56 46 65 44 C76 42 84 42 96 44" fill="none" stroke="rgba(33, 58, 112, 0.85)" stroke-width="10" stroke-linecap="round" opacity="0.35" />
+  <path d="M-5 68 C16 62 38 56 60 52 C74 49 86 50 110 54" fill="none" stroke="rgba(20, 36, 80, 0.65)" stroke-width="6" stroke-linecap="round" opacity="0.8" />
+  <path d="M0 40 C16 32 28 26 44 25 C58 23 74 28 100 18 L100 40 L0 40 Z" fill="url(#walk-river)" opacity="0.85" />
+  <g stroke="rgba(220, 228, 255, 0.16)" stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M10 92 L92 8" />
+    <path d="M3 78 L40 40" />
+    <path d="M35 95 L80 45" />
+    <path d="M12 14 L45 47" />
+    <path d="M64 12 L94 42" />
+  </g>
+  <g stroke="rgba(205, 215, 255, 0.35)" stroke-width="1.8" stroke-linecap="round">
+    <path d="M18 83 L36 70 L52 60 L70 52 L88 45" />
+    <path d="M58 20 L72 32 L86 40" />
+  </g>
+  <g fill="rgba(255, 255, 255, 0.12)">
+    <circle cx="20" cy="72" r="4" />
+    <circle cx="60" cy="52" r="3" />
+    <circle cx="86" cy="40" r="4.5" />
+    <circle cx="76" cy="20" r="3.5" />
+  </g>
+</svg>

--- a/public/images/maps/travel-002-train.svg
+++ b/public/images/maps/travel-002-train.svg
@@ -1,0 +1,39 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">羽田空港から渋谷までの鉄道マップ</title>
+  <desc id="desc">東京湾沿いから都心へ向かう鉄道ルートを表現したネオン調の地図。</desc>
+  <defs>
+    <linearGradient id="train-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1b0f2f" />
+      <stop offset="100%" stop-color="#0d1736" />
+    </linearGradient>
+    <radialGradient id="train-light" cx="0.75" cy="0.25" r="0.6">
+      <stop offset="0%" stop-color="rgba(255, 95, 200, 0.35)" />
+      <stop offset="100%" stop-color="rgba(27, 15, 47, 0)" />
+    </radialGradient>
+    <linearGradient id="train-water" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="rgba(30, 54, 110, 0.9)" />
+      <stop offset="100%" stop-color="rgba(14, 34, 84, 0.9)" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" fill="url(#train-bg)" />
+  <rect width="100" height="100" fill="url(#train-light)" opacity="0.45" />
+  <path d="M-5 78 C20 60 35 52 52 46 C68 40 82 32 105 18" fill="none" stroke="rgba(28, 50, 102, 0.8)" stroke-width="12" stroke-linecap="round" opacity="0.32" />
+  <path d="M-8 86 C22 66 44 54 66 44 C82 36 96 28 116 12" fill="none" stroke="rgba(18, 36, 90, 0.7)" stroke-width="7" stroke-linecap="round" opacity="0.8" />
+  <path d="M-2 68 L18 60 C32 54 48 52 66 52 C80 52 96 56 110 62 L110 90 L-2 90 Z" fill="url(#train-water)" opacity="0.85" />
+  <g stroke="rgba(210, 225, 255, 0.18)" stroke-width="1.15" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M8 12 L36 40" />
+    <path d="M18 6 L80 68" />
+    <path d="M38 4 L94 60" />
+    <path d="M12 96 L92 12" />
+  </g>
+  <g stroke="rgba(125, 200, 255, 0.35)" stroke-width="2" stroke-linecap="round">
+    <path d="M22 82 L38 70 L52 60 L66 54 L80 48 L90 40" />
+    <path d="M54 18 L70 30 L84 40" />
+  </g>
+  <g fill="rgba(255, 255, 255, 0.14)">
+    <circle cx="20" cy="72" r="3.5" />
+    <circle cx="42" cy="60" r="3" />
+    <circle cx="68" cy="48" r="3.8" />
+    <circle cx="86" cy="34" r="4.2" />
+  </g>
+</svg>

--- a/public/images/maps/travel-003-bus.svg
+++ b/public/images/maps/travel-003-bus.svg
@@ -1,0 +1,41 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">夏祭り会場へのバスルートマップ</title>
+  <desc id="desc">河川敷の夏祭りへ向かうバスルートを描いた涼しげな地図イラスト。</desc>
+  <defs>
+    <linearGradient id="bus-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0d1b34" />
+      <stop offset="100%" stop-color="#071024" />
+    </linearGradient>
+    <radialGradient id="bus-light" cx="0.22" cy="0.68" r="0.7">
+      <stop offset="0%" stop-color="rgba(120, 210, 255, 0.25)" />
+      <stop offset="100%" stop-color="rgba(13, 27, 52, 0)" />
+    </radialGradient>
+    <linearGradient id="bus-river" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="rgba(34, 80, 128, 0.88)" />
+      <stop offset="100%" stop-color="rgba(16, 46, 92, 0.9)" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" fill="url(#bus-bg)" />
+  <rect width="100" height="100" fill="url(#bus-light)" opacity="0.45" />
+  <path d="M-10 58 C12 52 32 48 52 44 C70 40 84 34 108 20" fill="none" stroke="rgba(30, 60, 110, 0.8)" stroke-width="11" stroke-linecap="round" opacity="0.3" />
+  <path d="M-4 62 C18 56 36 52 58 46 C74 42 88 36 108 26" fill="none" stroke="rgba(22, 44, 92, 0.75)" stroke-width="7" stroke-linecap="round" opacity="0.85" />
+  <path d="M-8 76 C12 70 32 64 52 58 C68 54 86 52 110 56 L110 100 L-8 100 Z" fill="url(#bus-river)" opacity="0.85" />
+  <g stroke="rgba(210, 228, 255, 0.18)" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M4 20 L48 64" />
+    <path d="M18 16 L60 58" />
+    <path d="M36 12 L84 60" />
+    <path d="M12 92 L88 16" />
+    <path d="M30 94 L96 28" />
+  </g>
+  <g stroke="rgba(180, 220, 255, 0.32)" stroke-width="2" stroke-linecap="round">
+    <path d="M18 74 L32 66 L46 58 L60 50 L72 42 L84 32" />
+    <path d="M52 18 L68 30 L82 40" />
+  </g>
+  <g fill="rgba(255, 255, 255, 0.16)">
+    <circle cx="20" cy="72" r="3.5" />
+    <circle cx="40" cy="60" r="3.2" />
+    <circle cx="64" cy="48" r="3.6" />
+    <circle cx="82" cy="34" r="4.1" />
+    <circle cx="72" cy="22" r="3" />
+  </g>
+</svg>

--- a/src/App.css
+++ b/src/App.css
@@ -7,7 +7,7 @@
   font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-x: hidden;
   overscroll-behavior: none;
 }
 
@@ -94,7 +94,13 @@
 .scene-container {
   flex: 1;
   display: flex;
-  padding: calc(env(safe-area-inset-top, 0px) + 1.75rem) 1.5rem calc(env(safe-area-inset-bottom, 0px) + 2.25rem);
+  padding: calc(env(safe-area-inset-top, 0px) + 1.75rem) 1.5rem calc(
+      env(safe-area-inset-bottom, 0px) + 2.25rem
+    );
+  overflow-y: auto;
+  min-height: 0;
+  width: 100%;
+  -webkit-overflow-scrolling: touch;
 }
 
 .scene-footer {
@@ -370,15 +376,6 @@
 .distance-hud__value {
   font-weight: 600;
   font-size: 0.95rem;
-}
-
-.distance-hud__goal {
-  display: inline-block;
-  margin-left: 0.4rem;
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(245, 244, 255, 0.7);
 }
 
 .result-grid {
@@ -811,7 +808,7 @@
   font-weight: 500;
 }
 
-.journeys-header__mode {
+.journeys-header__chip {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
@@ -825,8 +822,23 @@
   color: rgba(245, 244, 255, 0.82);
 }
 
-.journeys-header__mode span:first-child {
+.journeys-header__chip span:first-child {
   font-size: 1rem;
+}
+
+.journeys-header__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: rgba(245, 244, 255, 0.9);
+}
+
+.journeys-header__description {
+  margin: 0;
+  font-size: 0.92rem;
+  line-height: 1.6;
+  color: rgba(245, 244, 255, 0.75);
 }
 
 .journeys-progress-bar {
@@ -845,274 +857,129 @@
   transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.journeys-step-indicator {
-  display: flex;
-  gap: 0.4rem;
-  margin-top: 0.15rem;
-}
-
-.journeys-step-indicator__dot {
-  width: 0.6rem;
-  height: 0.6rem;
-  border-radius: 50%;
-  background: rgba(163, 174, 255, 0.28);
-  transition: transform 0.25s ease, background 0.25s ease;
-}
-
-.journeys-step-indicator__dot.is-complete {
-  background: rgba(255, 102, 196, 0.4);
-}
-
-.journeys-step-indicator__dot.is-current {
-  background: linear-gradient(135deg, #ff66c4, #4d7bff);
-  transform: scale(1.1);
-}
-
-.journeys-header__secondary {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.8rem;
-  letter-spacing: 0.08em;
-  color: rgba(245, 244, 255, 0.7);
-}
-
-.journeys-header__secondary span {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
 .journeys-stage {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-}
-
-.journey-map {
-  position: relative;
-  width: 100%;
-  border: none;
-  border-radius: 1.5rem;
-  padding: 1.1rem 1.2rem 1.45rem;
-  text-align: left;
-  color: #f5f4ff;
-  background: linear-gradient(145deg, rgba(19, 24, 62, 0.85), rgba(9, 12, 40, 0.95));
-  cursor: pointer;
+  gap: 1.4rem;
+  padding: clamp(1rem, 2vw, 1.45rem);
+  border-radius: 1.8rem;
+  background: linear-gradient(150deg, rgba(18, 24, 60, 0.82), rgba(8, 10, 32, 0.94));
+  border: 1px solid rgba(163, 174, 255, 0.22);
+  box-shadow: 0 24px 48px rgba(5, 8, 28, 0.45);
   overflow: hidden;
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 
-.journey-map:active {
-  transform: scale(0.98);
-}
-
-.journey-map:disabled {
-  cursor: default;
-  opacity: 0.85;
-}
-
-.journey-map__glow {
+.journeys-stage::before {
+  content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 18% 32%, rgba(255, 102, 196, 0.25), transparent 50%),
-    radial-gradient(circle at 82% 68%, rgba(77, 123, 255, 0.2), transparent 52%);
+  background: radial-gradient(
+      circle at 16% 18%,
+      rgba(255, 102, 196, 0.2),
+      transparent 55%
+    ),
+    radial-gradient(
+      circle at 78% 80%,
+      rgba(77, 123, 255, 0.16),
+      transparent 52%
+    );
+  opacity: 0.9;
   pointer-events: none;
 }
 
-.journey-map__line {
+.journeys-stage__page {
   position: relative;
-  height: 68px;
+  z-index: 1;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  flex-direction: column;
+  gap: 1.35rem;
 }
 
-.journey-map__line-track {
-  position: absolute;
-  left: 12%;
-  right: 12%;
-  height: 2px;
-  border-radius: 999px;
-  background: rgba(163, 174, 255, 0.35);
-  opacity: 0.7;
-}
-
-.journey-map__line-progress {
-  position: absolute;
-  left: 12%;
-  right: 12%;
-  height: 2px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 102, 196, 1), rgba(77, 123, 255, 1));
-  transform-origin: left center;
-  transform: scaleX(0);
-  opacity: 0;
-}
-
-.journey-map__line-progress[data-state='idle'] {
-  opacity: 0.35;
-}
-
-.journey-map__line-progress[data-state='animating'] {
-  opacity: 1;
-  animation: journey-progress 1.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-}
-
-.journey-map__line-progress[data-state='complete'] {
-  opacity: 1;
-  transform: scaleX(1);
-}
-
-.journey-map--route .journey-map__line {
-  display: none;
-}
-
-.journey-map__route-visual {
+.journeys-stage__advance {
   position: relative;
-  height: 76px;
-}
-
-.journey-map__route-visual svg {
-  width: 100%;
-  height: 100%;
-}
-
-.journey-map__route-track {
-  fill: none;
-  stroke: rgba(163, 174, 255, 0.35);
-  stroke-width: 2.4;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.journey-map__route-progress {
-  fill: none;
-  stroke: rgba(255, 102, 196, 0.95);
-  stroke-width: 2.8;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-dasharray: 400;
-  stroke-dashoffset: 400;
-  opacity: 0;
-  transition: stroke-dashoffset 1.45s cubic-bezier(0.22, 1, 0.36, 1),
-    opacity 0.3s ease;
-}
-
-.journey-map__route-progress[data-state='idle'] {
-  opacity: 0.35;
-}
-
-.journey-map__route-progress[data-state='animating'],
-.journey-map__route-progress[data-state='complete'] {
-  stroke-dashoffset: 0;
-  opacity: 1;
-}
-
-.journey-map__route-node {
-  fill: rgba(255, 102, 196, 0.85);
-  stroke: rgba(5, 5, 22, 0.8);
-  stroke-width: 0.6;
-}
-
-.journey-map__route-node--end {
-  fill: rgba(77, 123, 255, 0.9);
-}
-
-.journey-map__plane {
-  position: absolute;
-  top: var(--plane-from-y, 50%);
-  left: var(--plane-from-x, 12%);
-  width: 48px;
-  height: 48px;
-  transform: translate(-50%, -50%) rotate(-6deg);
-  filter: drop-shadow(0 6px 16px rgba(255, 102, 196, 0.35));
-}
-
-.journey-map__plane svg {
-  width: 100%;
-  height: 100%;
-}
-
-.journey-map__plane[data-state='animating'] {
-  animation: plane-fly 1.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-}
-
-.journey-map__plane[data-state='complete'] {
-  left: var(--plane-to-x, 88%);
-  top: var(--plane-to-y, 50%);
-  transform: translate(-50%, -50%) rotate(9deg);
-}
-
-.journey-map__plane--static {
-  animation: none !important;
-  left: var(--plane-to-x, 88%) !important;
-  top: var(--plane-to-y, 50%) !important;
-  transform: translate(-50%, -50%) rotate(6deg) !important;
-}
-
-.journey-map__plane--route {
-  width: 44px;
-  height: 44px;
-  border-radius: 50%;
-  background: rgba(6, 8, 24, 0.6);
-  border: 1px solid rgba(163, 174, 255, 0.3);
+  z-index: 1;
+  align-self: flex-end;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  filter: none;
-  color: #f5f4ff;
-}
-
-.journey-map__plane--route[data-state='animating'] {
-  animation: none;
-}
-
-.journey-map__route-icon {
-  font-size: 1.35rem;
-}
-
-.journey-map__labels {
-  position: absolute;
-  top: 0.8rem;
-  left: 12%;
-  right: 12%;
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.75rem;
-  letter-spacing: 0.16em;
+  gap: 0.55rem;
+  padding: 0.55rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 102, 196, 0.42);
+  background: rgba(8, 10, 32, 0.7);
+  color: rgba(245, 244, 255, 0.9);
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: rgba(245, 244, 255, 0.8);
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
 }
 
-.journey-map__status {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  margin-top: 1rem;
-  font-size: 0.82rem;
-  letter-spacing: 0.08em;
-  color: rgba(245, 244, 255, 0.82);
+.journeys-stage__advance:hover,
+.journeys-stage__advance:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(255, 102, 196, 0.65);
+  background: rgba(16, 20, 56, 0.78);
+  outline: none;
+}
+
+.journeys-stage__advance span:last-child {
+  font-size: 1rem;
+}
+
+.journeys-stage__hint {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  align-self: flex-end;
+  font-size: 0.78rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.68);
 }
 
 .journey-card {
-  display: grid;
-  gap: 1.4rem;
-  padding: 1.4rem;
-  border-radius: 1.5rem;
-  background: rgba(16, 21, 55, 0.6);
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1.35rem;
+  padding: 1.35rem;
+  border-radius: 1.6rem;
+  background: rgba(12, 16, 48, 0.7);
   border: 1px solid rgba(163, 174, 255, 0.22);
-  box-shadow: 0 18px 40px rgba(4, 6, 22, 0.35);
+  box-shadow: 0 20px 38px rgba(5, 8, 26, 0.45);
+  backdrop-filter: blur(6px);
 }
 
-@media (min-width: 720px) {
-  .journey-card {
-    grid-template-columns: minmax(220px, 0.85fr) minmax(0, 1fr);
-  }
+.journey-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.journey-card__headline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.journey-card__map {
+  position: relative;
+}
+
+.journey-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .journey-card__media {
   position: relative;
-  border-radius: 1.25rem;
+  border-radius: 1.35rem;
   overflow: hidden;
   min-height: 220px;
   background-size: cover;
@@ -1151,31 +1018,12 @@
   font-size: 1rem;
 }
 
-.journey-card__body {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.journey-card__meta {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  gap: 1rem;
-}
-
 .journey-status {
   padding: 0.25rem 0.85rem;
   border-radius: 999px;
   font-size: 0.7rem;
   letter-spacing: 0.3em;
   text-transform: uppercase;
-}
-
-.journey-status--pending {
-  background: rgba(15, 20, 56, 0.75);
-  border: 1px solid rgba(163, 174, 255, 0.28);
-  color: rgba(245, 244, 255, 0.75);
 }
 
 .journey-status--arrived {
@@ -1206,7 +1054,11 @@
   font-size: 0.85rem;
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: rgba(245, 244, 255, 0.7);
+  color: rgba(245, 244, 255, 0.75);
+}
+
+.journey-card__transport span:first-child {
+  font-size: 1.1rem;
 }
 
 .journey-card__city {
@@ -1225,49 +1077,25 @@
   color: rgba(245, 244, 255, 0.92);
 }
 
-.journey-card__transport span:first-child {
-  font-size: 1.1rem;
-}
-
-.journey-card__caption {
-  margin: 0;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  color: rgba(245, 244, 255, 0.85);
-}
-
 .journey-card__text-group {
   display: flex;
   flex-direction: column;
   gap: 0.65rem;
 }
 
-.journey-card__stats {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1rem;
-}
-
-.journey-card__stat-label {
+.journey-card__caption {
   margin: 0;
-  font-size: 0.75rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(245, 244, 255, 0.6);
-}
-
-.journey-card__stat-value {
-  margin: 0.35rem 0 0;
-  font-size: 1.2rem;
-  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: rgba(245, 244, 255, 0.86);
 }
 
 .journey-card__meta-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
   gap: 0.75rem 1.2rem;
-  margin: 1rem 0 0;
-  padding-top: 0.85rem;
+  margin: 0.5rem 0 0;
+  padding-top: 0.9rem;
   border-top: 1px solid rgba(163, 174, 255, 0.16);
   font-size: 0.75rem;
   letter-spacing: 0.12em;
@@ -1289,6 +1117,98 @@
 .journey-card__meta-note dd {
   font-size: 0.82rem;
   line-height: 1.6;
+}
+
+@media (min-width: 780px) {
+  .journey-card--episode {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.75fr) minmax(0, 1fr);
+    gap: 1.6rem;
+  }
+}
+
+.journey-map {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.journey-map__surface {
+  position: relative;
+  border-radius: 1.4rem;
+  overflow: hidden;
+  background: linear-gradient(145deg, rgba(19, 24, 62, 0.9), rgba(9, 12, 40, 0.95));
+  border: 1px solid rgba(163, 174, 255, 0.22);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.journey-map__surface svg,
+.journey-map__image {
+  width: 100%;
+  display: block;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.journey-map__overlay {
+  position: absolute;
+  inset: 0;
+}
+
+.journey-map__orbit {
+  fill: none;
+  stroke: rgba(80, 110, 200, 0.18);
+  stroke-width: 6;
+}
+
+.journey-map__track {
+  fill: none;
+  stroke: rgba(163, 174, 255, 0.28);
+  stroke-width: 2.1;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.journey-map__route {
+  fill: none;
+  stroke: rgba(255, 102, 196, 0.95);
+  stroke-width: 2.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  filter: drop-shadow(0 0 6px rgba(255, 102, 196, 0.4));
+}
+
+.journey-map--flight .journey-map__route {
+  stroke-width: 3.1;
+}
+
+.journey-map__node {
+  fill: #f5f4ff;
+  stroke: rgba(15, 20, 56, 0.7);
+  stroke-width: 1.3;
+}
+
+.journey-map__node--end {
+  fill: #ffb2e2;
+}
+
+.journey-map__caption {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(245, 244, 255, 0.6);
+}
+
+.journey-map__placeholder {
+  display: grid;
+  place-items: center;
+  padding: 2.5rem 1rem;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  text-align: center;
+  color: rgba(245, 244, 255, 0.65);
 }
 
 .journey-prompts {
@@ -1472,46 +1392,10 @@
   box-shadow: 0 12px 24px rgba(77, 123, 255, 0.25);
 }
 
-@keyframes journey-progress {
-  0% {
-    transform: scaleX(0);
-  }
-  100% {
-    transform: scaleX(1);
-  }
-}
-
-@keyframes plane-fly {
-  0% {
-    left: var(--plane-from-x, 12%);
-    top: var(--plane-from-y, 50%);
-    transform: translate(-50%, -50%) rotate(-6deg);
-  }
-  100% {
-    left: var(--plane-to-x, 88%);
-    top: var(--plane-to-y, 50%);
-    transform: translate(-50%, -50%) rotate(9deg);
-  }
-}
-
 @media (max-width: 520px) {
   .journeys-header__row {
     flex-direction: column;
     align-items: flex-start;
-  }
-  .journeys-header__secondary {
-    flex-direction: column;
-    gap: 0.35rem;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .journey-map__line-progress[data-state='animating'] {
-    animation: none;
-    transform: scaleX(1);
-  }
-  .journey-map__plane[data-state='animating'] {
-    animation: none;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,10 +102,7 @@ function App() {
   return (
     <div className={`app-shell scene-${currentSceneId}`}>
       {currentSceneId !== 'intro' && <GlobalStarfield />}
-      <DistanceHUD
-        distanceKm={distanceTraveled}
-        goalKm={totalJourneyDistance}
-      />
+      <DistanceHUD distanceKm={distanceTraveled} />
       <main className="scene-container">
         {renderScene(currentSceneId, sceneProps)}
       </main>

--- a/src/components/DistanceHUD.tsx
+++ b/src/components/DistanceHUD.tsx
@@ -1,6 +1,5 @@
 interface DistanceHUDProps {
   distanceKm: number
-  goalKm?: number
 }
 
 const formatDistance = (distanceKm: number) =>
@@ -8,17 +7,11 @@ const formatDistance = (distanceKm: number) =>
     maximumFractionDigits: 0,
   }).format(Math.round(distanceKm))
 
-export const DistanceHUD = ({ distanceKm, goalKm }: DistanceHUDProps) => {
-  const hasGoal = typeof goalKm === 'number'
+export const DistanceHUD = ({ distanceKm }: DistanceHUDProps) => {
   return (
     <div className="distance-hud" aria-live="polite">
       <span className="distance-hud__label">TOTAL DISTANCE</span>
-      <span className="distance-hud__value">
-        {formatDistance(distanceKm)} km
-        {hasGoal ? (
-          <span className="distance-hud__goal"> / {formatDistance(goalKm!)} km</span>
-        ) : null}
-      </span>
+      <span className="distance-hud__value">{formatDistance(distanceKm)} km</span>
     </div>
   )
 }

--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -55,6 +55,11 @@ const journeyDefinitions: JourneyInput[] = [
           [68, 58],
           [78, 52],
         ],
+        mapIllustration: {
+          src: '/images/maps/travel-001-walk.svg',
+          alt: '福岡空港から博多駅前までの徒歩ルートを描いた夜景マップ',
+          caption: '空港連絡通路から博多駅方面へ向かう道筋を夜景のトーンで表現した地図',
+        },
         description: '空港の通路を抜け、夕方の風を浴びながらホテルへ向かった。',
       },
       {
@@ -147,6 +152,11 @@ const journeyDefinitions: JourneyInput[] = [
           [55, 38],
           [72, 28],
         ],
+        mapIllustration: {
+          src: '/images/maps/travel-002-train.svg',
+          alt: '羽田空港から渋谷へ向かう鉄道路線をネオンで描いた地図',
+          caption: '東京湾沿いから都心部へ向かう夜景のラインを記録したビジュアルマップ',
+        },
         meta: {
           note: '空港線から渋谷まで乗り換え1回。',
         },
@@ -214,6 +224,11 @@ const journeyDefinitions: JourneyInput[] = [
           [74, 34],
           [82, 26],
         ],
+        mapIllustration: {
+          src: '/images/maps/travel-003-bus.svg',
+          alt: '福岡空港から夏祭りの会場へ向かうバスルートを描いた地図',
+          caption: '河川敷の灯りと臨時バスのラインをブルートーンでまとめた地図イラスト',
+        },
         meta: {
           note: '臨時バスで30分ほどの移動。',
         },

--- a/src/types/journey.ts
+++ b/src/types/journey.ts
@@ -25,6 +25,12 @@ export interface JourneyMoveStep {
   toCoord?: JourneyCoordinate
   /** 抽象マップ上のルート。 */
   route?: JourneyCoordinate[]
+  /** 実際の地図を差し込む場合のイラスト情報。 */
+  mapIllustration?: {
+    src: string
+    alt: string
+    caption?: string
+  }
   /** フライト番号や発着時間などの補足情報。 */
   meta?: JourneyMoveMeta
   /** ステップ固有のラベルや補足文。 */


### PR DESCRIPTION
## Summary
- rebuild the journeys scene into a sequential storybook that alternates move, memory, and question pages with tap-to-advance controls and distance tracking updates
- add reusable move, episode, and question card components that render dynamic flight arcs or illustrated ground maps backed by new SVG assets
- refresh the journeys styles to support the new stage layout, allow scrolling, and introduce map illustration slots on non-flight steps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf5c2fd644832fa793dac8634a55fc