### PR TITLE
Refine result header and carousel styling

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -2,14 +2,14 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(18px, 3vw, 28px);
-  padding: clamp(12px, 2.6vw, 20px) clamp(20px, 4vw, 40px) clamp(24px, 3.2vw, 36px);
-  border-radius: 28px;
-  background: radial-gradient(circle at top, rgba(241, 210, 122, 0.18), transparent 55%),
-    linear-gradient(180deg, #0b0d10 0%, #0e1114 100%);
+  gap: clamp(12px, 2.2vw, 24px);
+  padding: 0 clamp(20px, 4vw, 36px) clamp(26px, 3.4vw, 40px);
+  border-radius: 24px;
+  background: linear-gradient(180deg, rgba(7, 9, 12, 0.98) 0%, rgba(13, 16, 22, 0.96) 100%);
   color: #ffffff;
-  box-shadow: 0 30px 90px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.6);
   isolation: isolate;
+  overflow: hidden;
 }
 
 .result-screen__backdrop {
@@ -24,32 +24,42 @@
 }
 
 .result-screen__header {
+  position: sticky;
+  top: 0;
+  left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: clamp(12px, 2vw, 18px);
-  padding-top: clamp(4px, 1.4vw, 12px);
-  width: 100%;
-  position: relative;
+  align-items: stretch;
+  gap: clamp(6px, 1.4vw, 14px);
+  padding: clamp(8px, 1.6vw, 14px) 0 clamp(10px, 1.8vw, 16px);
+  background: linear-gradient(180deg, rgba(7, 8, 11, 0.96), rgba(11, 13, 18, 0.96));
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.65);
+  z-index: 5;
+  border-top-left-radius: 24px;
+  border-top-right-radius: 24px;
 }
 
 .result-tabbar {
+  position: relative;
   display: flex;
-  align-items: flex-end;
   justify-content: center;
-  gap: 0;
-  height: clamp(42px, 5vw, 48px);
-  margin: 0 auto clamp(6px, 1.6vw, 12px);
-  padding-inline: clamp(10px, 2vw, 18px);
-  width: max-content;
+  width: 100%;
+  margin: 0 auto;
+  padding-inline: clamp(20px, 3vw, 36px);
 }
 
 .result-tabbar__list {
-  display: flex;
-  gap: 0;
+  display: inline-flex;
+  align-items: stretch;
   list-style: none;
-  padding: 0;
+  padding: clamp(2px, 0.6vw, 4px);
   margin: 0;
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, rgba(25, 26, 32, 0.95), rgba(11, 12, 16, 0.95));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .result-tabbar__item {
@@ -57,64 +67,33 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100%;
-  min-width: clamp(100px, 22vw, 140px);
+  min-width: clamp(96px, 22vw, 148px);
   padding: 0 clamp(16px, 4vw, 28px);
-  background: linear-gradient(180deg, rgba(23, 24, 29, 0.96), rgba(9, 10, 13, 0.96));
-  color: rgba(255, 255, 255, 0.62);
-  font-size: 0.78rem;
-  letter-spacing: 0.26em;
+  height: clamp(34px, 4vw, 42px);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 0.7rem;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  transform: skewX(-18deg);
-  transition: color 140ms ease;
+  transition: color 140ms ease, background 140ms ease;
+}
+
+.result-tabbar__item:hover {
+  color: rgba(255, 255, 255, 0.72);
 }
 
 .result-tabbar__item + .result-tabbar__item {
-  margin-left: -14px;
-}
-
-.result-tabbar__item::before {
-  content: '';
-  position: absolute;
-  top: 10px;
-  bottom: 10px;
-  right: -2px;
-  width: 1px;
-  background: rgba(255, 255, 255, 0.1);
-  transform: skewX(18deg);
-}
-
-.result-tabbar__item::after {
-  content: '';
-  position: absolute;
-  left: clamp(18px, 4vw, 32px);
-  right: clamp(18px, 4vw, 32px);
-  bottom: -2px;
-  height: 2px;
-  background: transparent;
-  transform: skewX(18deg);
-  border-radius: 2px;
-}
-
-.result-tabbar__item:first-child::before {
-  display: none;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .result-tabbar__item.is-active {
-  background: linear-gradient(180deg, #881519, #d3222e);
+  background: linear-gradient(180deg, #57060c 0%, #a9151f 52%, #d3202b 100%);
   color: #ffe6cf;
-  z-index: 1;
-}
-
-.result-tabbar__item.is-active::after {
-  background: linear-gradient(90deg, rgba(255, 91, 74, 0), #ffd7a4 45%, rgba(255, 91, 74, 0));
-  height: 3px;
-  bottom: -1px;
+  box-shadow: inset 0 1px 0 rgba(255, 191, 175, 0.25);
 }
 
 .result-tabbar__label {
   display: block;
-  transform: skewX(18deg);
   pointer-events: none;
 }
 
@@ -122,201 +101,281 @@
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: clamp(12px, 3vw, 32px);
-  padding: clamp(10px, 2vw, 16px) clamp(22px, 4vw, 36px);
-  border-radius: 8px;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: clamp(10px, 2.4vw, 26px);
+  padding: clamp(6px, 1.2vw, 10px) clamp(18px, 3.2vw, 32px);
+  border-radius: 9px;
   overflow: hidden;
-  min-height: clamp(56px, 8vw, 74px);
-  background: linear-gradient(90deg, rgba(152, 102, 10, 0.78) 0%, rgba(236, 203, 122, 0.62) 48%, rgba(152, 102, 10, 0.78) 100%);
-  backdrop-filter: blur(6px);
+  min-height: clamp(46px, 6vw, 64px);
+  background: linear-gradient(90deg, #9d7c2e 0%, #c4a349 50%, #e6cf7b 100%);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.48);
+  margin-inline: clamp(20px, 3vw, 36px);
 }
 
 .result-banner__surface {
   position: absolute;
-  inset: -15% -8%;
-  background: radial-gradient(circle at 30% -45%, rgba(255, 255, 255, 0.45), transparent 75%),
-    radial-gradient(circle at 78% 60%, rgba(255, 239, 196, 0.18), transparent 72%);
-  opacity: 0.6;
+  inset: -40% -20%;
+  background: radial-gradient(circle at 12% -50%, rgba(255, 255, 255, 0.45), transparent 70%),
+    radial-gradient(circle at 88% 40%, rgba(255, 248, 225, 0.32), transparent 70%);
+  opacity: 0.4;
   pointer-events: none;
 }
 
 .result-banner__streak {
   position: absolute;
   top: 50%;
-  left: -20%;
-  width: 140%;
-  height: 120px;
-  background: linear-gradient(90deg, rgba(255, 243, 204, 0.24) 0%, rgba(255, 255, 255, 0.05) 45%, rgba(255, 243, 204, 0.24) 100%);
+  left: -18%;
+  width: 130%;
+  height: 96px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 243, 210, 0.22) 50%, rgba(255, 255, 255, 0.32) 100%);
   transform: translateY(-50%);
-  filter: blur(32px);
-  opacity: 0.55;
+  filter: blur(22px);
+  opacity: 0.45;
   pointer-events: none;
 }
 
 .result-banner::before {
   content: '';
   position: absolute;
+  top: 0;
   left: 0;
   right: 0;
-  top: 0;
   height: 2px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.7), rgba(255, 255, 255, 0.1));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.35));
+  opacity: 0.85;
+  pointer-events: none;
 }
 
 .result-banner::after {
   content: '';
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 2px;
-  background: linear-gradient(90deg, rgba(18, 9, 3, 0.7), rgba(18, 9, 3, 0.1));
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(255, 238, 209, 0.38);
+  box-shadow: inset 0 -1px 0 rgba(84, 54, 19, 0.45);
+  pointer-events: none;
 }
 
 .result-banner__title {
+  position: relative;
   margin: 0;
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  max-width: min(70%, 520px);
-  padding: 0 clamp(24px, 10vw, 72px);
-  text-align: center;
-  font-size: clamp(1.8rem, 4.2vw, 2.3rem);
+  flex: 1;
+  max-width: 420px;
+  text-align: left;
+  font-size: clamp(1.5rem, 3.6vw, 2.1rem);
   font-weight: 700;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: #fff7e8;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  line-height: 1.05;
+  color: #fff7dc;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+  line-height: 1.02;
   z-index: 1;
+}
+
+.result-banner__title::before {
+  content: '';
+  position: absolute;
+  left: -20px;
+  top: 50%;
+  width: clamp(14px, 1.8vw, 20px);
+  height: 1px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 254, 240, 0.85));
+  transform: translateY(-50%);
 }
 
 .result-banner__stats {
   position: relative;
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: flex-end;
-  gap: clamp(12px, 2.6vw, 24px);
-  row-gap: 0.4rem;
+  gap: clamp(10px, 2vw, 18px);
   margin-left: auto;
-  flex-wrap: wrap;
+  white-space: nowrap;
   z-index: 1;
 }
 
 .result-banner__panel {
   display: inline-flex;
   align-items: baseline;
-  gap: 0.55rem;
-  color: rgba(255, 231, 189, 0.9);
+  gap: clamp(6px, 1.5vw, 12px);
+  padding: 0;
+  background: transparent;
+  border: none;
 }
 
 .result-banner__panel-label {
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
+  font-size: 0.62rem;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(243, 212, 146, 0.8);
+  color: rgba(54, 35, 9, 0.7);
 }
 
 .result-banner__panel-value {
-  font-size: clamp(1.45rem, 3.4vw, 1.85rem);
+  font-size: clamp(1.2rem, 2.6vw, 1.6rem);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: #ffecc0;
-  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  color: #2b1b05;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.result-header__divider {
+  width: calc(100% - clamp(40px, 6vw, 72px));
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.05),
+    rgba(255, 255, 255, 0.24),
+    rgba(255, 255, 255, 0.05)
+  );
+  margin: 0 auto;
 }
 
 .result-cards {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(16px, 2vw, 26px);
+  margin-top: clamp(10px, 2vw, 24px);
+  position: relative;
+}
+
+.result-cards__viewport {
+  position: relative;
+  overflow: visible;
+  border-radius: 0;
+}
+
+.result-cards__track {
+  --active-index: 0;
   display: grid;
-  grid-template-columns: repeat(2, minmax(260px, 1fr));
-  gap: clamp(20px, 4vw, 40px);
-  margin-top: clamp(12px, 2.5vw, 28px);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(20px, 3.2vw, 36px);
+  transition: transform 280ms ease;
+  will-change: transform;
 }
 
 .result-card {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) clamp(180px, 26vw, 240px);
-  gap: clamp(16px, 3vw, 28px);
-  padding: clamp(18px, 3vw, 28px);
-  border-radius: 16px;
-  background: linear-gradient(160deg, rgba(15, 18, 22, 0.92), rgba(12, 14, 18, 0.88));
+  grid-template-columns: minmax(0, 1fr) clamp(200px, 28vw, 260px);
+  gap: clamp(14px, 2.6vw, 24px);
+  padding: clamp(18px, 2.8vw, 26px);
+  border-radius: 14px;
+  background: linear-gradient(160deg, rgba(12, 14, 20, 0.96) 0%, rgba(6, 7, 12, 0.96) 72%);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.58);
+  overflow: hidden;
   transition: transform 120ms ease, box-shadow 150ms ease, border-color 150ms ease;
 }
 
+.result-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(130deg, rgba(255, 215, 165, 0.14), transparent 58%);
+  pointer-events: none;
+}
+
 .result-card:hover,
-.result-card:focus-within {
-  transform: scale(1.02);
-  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.6);
-  border-color: rgba(241, 210, 122, 0.35);
+.result-card:focus-within,
+.result-card.is-active {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 52px rgba(0, 0, 0, 0.68);
+  border-color: rgba(241, 210, 122, 0.3);
 }
 
 .result-card__body {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: clamp(12px, 2.5vw, 20px);
+  gap: clamp(12px, 2.5vw, 18px);
   min-width: 0;
+  z-index: 1;
 }
 
 .result-card__header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .result-card__title {
   margin: 0;
-  font-size: clamp(1.35rem, 3.2vw, 1.9rem);
-  font-weight: 600;
-  letter-spacing: 0.04em;
+  font-size: clamp(1.28rem, 3vw, 1.72rem);
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
 }
 
 .result-card__stats {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: clamp(10px, 2.3vw, 18px);
+  gap: clamp(6px, 1.8vw, 12px);
 }
 
 .result-card__stat {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: baseline;
+  gap: clamp(8px, 2vw, 14px);
+  padding-block: 2px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.result-card__stat:last-child {
+  border-bottom: none;
 }
 
 .result-card__label {
-  font-size: 0.9rem;
-  letter-spacing: 0.03em;
-  color: rgba(201, 209, 217, 0.85);
+  font-size: 0.62rem;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: rgba(177, 188, 198, 0.78);
   margin: 0;
 }
 
 .result-card__value {
   margin: 0;
-  font-size: clamp(1.15rem, 3vw, 1.5rem);
-  font-weight: 600;
+  font-size: clamp(1.05rem, 2.6vw, 1.42rem);
+  font-weight: 700;
   font-variant-numeric: tabular-nums;
   color: #ffffff;
+  text-align: right;
 }
 
 .result-card__image {
   position: relative;
-  border-radius: 12px;
-  min-height: clamp(200px, 30vw, 280px);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: linear-gradient(180deg, rgba(40, 44, 54, 0.85), rgba(15, 18, 26, 0.95));
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
-  overflow: hidden;
+  border-radius: 14px;
+  padding: 10px;
+  min-height: clamp(220px, 34vw, 320px);
+  background: linear-gradient(160deg, rgba(24, 26, 34, 0.95), rgba(10, 11, 16, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 16px 34px rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  z-index: 1;
 }
 
 .result-card__image::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 50% 0%, rgba(241, 210, 122, 0.18), transparent 65%);
+  border-radius: inherit;
+  background: linear-gradient(130deg, rgba(255, 216, 167, 0.14), transparent 60%);
   pointer-events: none;
+}
+
+.result-card__image-inner {
+  position: relative;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(180deg, rgba(34, 38, 48, 0.92), rgba(10, 12, 20, 0.95));
+  min-height: 100%;
 }
 
 .result-card__image-placeholder {
@@ -325,11 +384,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 16px;
+  padding: 18px;
   text-align: center;
-  font-size: 0.85rem;
-  letter-spacing: 0.04em;
-  color: rgba(122, 130, 138, 0.9);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: rgba(136, 146, 158, 0.9);
   transition: opacity 160ms ease;
 }
 
@@ -339,7 +398,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 12px;
+  border-radius: 8px;
   opacity: 0;
   transition: opacity 220ms ease;
 }
@@ -355,6 +414,7 @@
 .result-action {
   display: flex;
   justify-content: flex-end;
+  margin-top: clamp(8px, 1.8vw, 14px);
 }
 
 .result-action__button {
@@ -362,129 +422,219 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.6rem;
-  padding: 0.9rem 2.8rem;
+  gap: 0.4rem;
+  padding: 0.55rem 1.6rem;
   border-radius: 999px;
-  border: 1px solid rgba(241, 210, 122, 0.38);
-  background: linear-gradient(135deg, #8c111c 0%, #b01e2d 50%, #d42440 100%);
-  color: #ffffff;
-  font-size: 1rem;
-  letter-spacing: 0.16em;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(180deg, rgba(39, 42, 52, 0.92), rgba(20, 23, 30, 0.92));
+  color: rgba(220, 225, 230, 0.92);
+  font-size: 0.78rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.45);
   cursor: pointer;
   transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
 }
 
+.result-cards__nav {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(12px, 3vw, 24px);
+  margin-top: clamp(12px, 3vw, 20px);
+}
+
+.result-cards__nav-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(241, 210, 122, 0.4);
+  background: rgba(27, 28, 34, 0.85);
+  color: #ffe6cf;
+  font-size: 1.8rem;
+  line-height: 1;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.result-cards__nav-button:hover,
+.result-cards__nav-button:focus-visible {
+  background: linear-gradient(135deg, rgba(240, 203, 126, 0.85), rgba(173, 132, 46, 0.85));
+  color: #301107;
+  transform: translateY(-1px);
+  box-shadow: 0 0 18px rgba(241, 210, 122, 0.55);
+}
+
+.result-cards__nav-button:focus-visible {
+  outline: 2px solid rgba(241, 210, 122, 0.85);
+  outline-offset: 3px;
+}
+
+.result-cards__dots {
+  display: flex;
+  align-items: center;
+  gap: clamp(8px, 2vw, 16px);
+}
+
+.result-cards__dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid rgba(241, 210, 122, 0.4);
+  background: rgba(27, 28, 34, 0.85);
+  cursor: pointer;
+  transition: background 150ms ease, transform 120ms ease;
+}
+
+.result-cards__dot.is-active {
+  background: linear-gradient(135deg, #f1d27a 0%, #b8860b 100%);
+  transform: scale(1.1);
+}
+
+.result-cards__dot:focus-visible {
+  outline: 2px solid rgba(241, 210, 122, 0.85);
+  outline-offset: 2px;
+}
+
 .result-action__button:hover,
 .result-action__button:focus-visible {
-  background: linear-gradient(135deg, #b8860b 0%, #f1d27a 60%, #b8860b 100%);
-  box-shadow: 0 0 18px rgba(241, 210, 122, 0.75);
-  transform: translateY(-2px);
+  background: linear-gradient(180deg, rgba(60, 64, 74, 0.95), rgba(32, 34, 42, 0.95));
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.55);
+  transform: translateY(-1px);
 }
 
 .result-action__button:focus-visible {
-  outline: 2px solid rgba(241, 210, 122, 0.85);
+  outline: 2px solid rgba(241, 210, 122, 0.45);
   outline-offset: 4px;
 }
 
 .result-action__button:active {
   transform: translateY(0);
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.5);
 }
 
 @media (max-width: 1024px) {
   .result-card {
-    grid-template-columns: minmax(0, 1fr) clamp(160px, 32vw, 220px);
+    grid-template-columns: minmax(0, 1fr) clamp(180px, 34vw, 236px);
   }
 }
 
-@media (max-width: 900px) {
-  .result-cards {
-    grid-template-columns: 1fr;
+@media (max-width: 960px) {
+  .result-cards__viewport {
+    border-radius: 12px;
+    overflow: hidden;
+  }
+
+  .result-cards__track {
+    display: flex;
+    gap: 0;
+    width: 100%;
+    transform: translateX(calc(var(--active-index, 0) * -100%));
   }
 
   .result-card {
-    grid-template-columns: minmax(0, 1fr) clamp(150px, 38vw, 210px);
-    gap: clamp(14px, 4vw, 24px);
+    flex: 0 0 100%;
+    max-width: 100%;
+    grid-template-columns: minmax(0, 1fr) clamp(168px, 48vw, 210px);
   }
 
-  .result-card__image {
-    order: 0;
-    min-height: clamp(170px, 48vw, 220px);
+  .result-card:hover,
+  .result-card:focus-within {
+    transform: none;
+  }
+
+  .result-card.is-active {
+    transform: none;
+  }
+
+  .result-cards__nav {
+    display: flex;
   }
 }
 
 @media (max-width: 640px) {
   .result-screen {
     border-radius: 20px;
-    padding: clamp(10px, 4.5vw, 18px) clamp(14px, 5vw, 24px) clamp(18px, 5vw, 26px);
+    padding: 0 clamp(14px, 5vw, 24px) clamp(18px, 5vw, 26px);
   }
 
   .result-screen__header {
-    gap: clamp(10px, 4vw, 16px);
-  }
-
-  .result-banner {
-    border-radius: 9px;
-    flex-wrap: wrap;
-    justify-content: center;
-    row-gap: clamp(8px, 4vw, 12px);
-    min-height: auto;
-    padding: clamp(12px, 5vw, 20px) clamp(16px, 6vw, 24px);
-  }
-
-  .result-banner__title {
-    position: static;
-    transform: none;
-    max-width: none;
-    width: 100%;
-    padding: 0;
-  }
-
-  .result-banner__stats {
-    width: 100%;
-    justify-content: center;
-    gap: clamp(8px, 5vw, 16px);
-    margin-left: 0;
-  }
-
-  .result-banner__panel {
-    flex: 0 1 auto;
-    align-items: baseline;
-    justify-content: center;
-    flex-wrap: wrap;
-    gap: 0.45rem;
-  }
-
-  .result-banner__panel-value {
-    font-size: clamp(1.35rem, 6vw, 1.7rem);
-  }
-
-  .result-tabbar {
-    height: clamp(38px, 10vw, 44px);
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    padding: clamp(10px, 4vw, 16px) clamp(8px, 3vw, 14px) clamp(12px, 4vw, 18px);
+    gap: clamp(8px, 3vw, 14px);
   }
 
   .result-tabbar__item {
-    min-width: clamp(88px, 30vw, 112px);
-    padding: 0 clamp(12px, 5vw, 18px);
+    min-width: clamp(92px, 32vw, 120px);
+    padding: 0 clamp(12px, 6vw, 18px);
+    height: clamp(34px, 11vw, 40px);
+    font-size: 0.68rem;
+    letter-spacing: 0.22em;
   }
 
-  .result-tabbar__label {
-    font-size: 0.72rem;
-    letter-spacing: 0.2em;
+  .result-tabbar {
+    padding-inline: clamp(12px, 8vw, 20px);
+  }
+
+  .result-banner {
+    padding: clamp(6px, 3.4vw, 10px) clamp(14px, 6vw, 22px);
+    min-height: clamp(44px, 12vw, 56px);
+    gap: clamp(8px, 4vw, 14px);
+    margin-inline: clamp(12px, 6vw, 24px);
+  }
+
+  .result-header__divider {
+    width: calc(100% - clamp(24px, 12vw, 48px));
+  }
+
+  .result-banner__title {
+    font-size: clamp(1.32rem, 7vw, 1.7rem);
+    letter-spacing: 0.18em;
+  }
+
+  .result-banner__title::before {
+    display: none;
+  }
+
+  .result-banner__stats {
+    gap: clamp(6px, 4vw, 12px);
+  }
+
+  .result-banner__panel-label {
+    font-size: 0.56rem;
+  }
+
+  .result-banner__panel-value {
+    font-size: clamp(1rem, 5.8vw, 1.28rem);
   }
 
   .result-card {
-    padding: clamp(14px, 4vw, 20px);
+    padding: clamp(16px, 6vw, 22px);
+    grid-template-columns: minmax(0, 1fr) clamp(150px, 54vw, 190px);
   }
 
   .result-card__image {
-    min-height: clamp(150px, 56vw, 210px);
+    min-height: clamp(200px, 68vw, 260px);
   }
 
-  .result-action__button {
-    width: 100%;
+  .result-cards__nav {
+    gap: clamp(14px, 6vw, 22px);
+  }
+
+  .result-cards__nav-button {
+    width: clamp(40px, 12vw, 48px);
+    height: clamp(40px, 12vw, 48px);
+    font-size: clamp(1.5rem, 6vw, 2rem);
+  }
+
+  .result-cards__dot {
+    width: clamp(10px, 3.2vw, 12px);
+    height: clamp(10px, 3.2vw, 12px);
   }
 }
 


### PR DESCRIPTION
## Summary
- restyle the sticky result header so the tab set, divider, and gold champion banner mirror the metallic reference layout with inline rank and kill stats
- tighten the player card composition with condensed stat typography, framed poster art, and a de-emphasized lobby CTA to match the homage
- add a touch-aware carousel viewport and responsive rules so only one player card shows on mobile while preserving the split stats/image design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d74ca8a1d4832f8313697b7c5dd644