### PR TITLE
Refine result scene tab and banner responsiveness

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -43,53 +43,69 @@
 .result-tabbar {
   position: relative;
   display: flex;
-  justify-content: center;
   width: 100%;
   margin: 0 auto;
-  padding-inline: clamp(20px, 3vw, 36px);
+  padding-inline: clamp(10px, 2.2vw, 24px);
 }
 
 .result-tabbar__list {
-  display: inline-flex;
+  display: flex;
   align-items: stretch;
+  justify-content: stretch;
   list-style: none;
-  padding: clamp(2px, 0.6vw, 4px);
+  padding: clamp(2px, 0.5vw, 4px);
   margin: 0;
-  border-radius: 999px;
-  overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: linear-gradient(180deg, rgba(25, 26, 32, 0.95), rgba(11, 12, 16, 0.95));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  width: 100%;
+  gap: clamp(4px, 0.8vw, 10px);
+  border-radius: clamp(22px, 3vw, 36px);
+  background: linear-gradient(180deg, rgba(20, 22, 28, 0.9), rgba(9, 10, 14, 0.9));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .result-tabbar__item {
   position: relative;
+  flex: 1 1 0;
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: clamp(96px, 22vw, 148px);
-  padding: 0 clamp(16px, 4vw, 28px);
-  height: clamp(34px, 4vw, 42px);
-  background: transparent;
-  color: rgba(255, 255, 255, 0.55);
-  font-size: 0.7rem;
-  letter-spacing: 0.24em;
+  padding: 0 clamp(10px, 3vw, 18px);
+  height: clamp(36px, 4vw, 44px);
+  clip-path: polygon(9% 0, 100% 0, 91% 100%, 0 100%);
+  color: rgba(255, 255, 255, 0.62);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  transition: color 140ms ease, background 140ms ease;
+  overflow: hidden;
+  isolation: isolate;
+  transition: color 160ms ease;
+}
+
+.result-tabbar__item::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.86);
+  transition: opacity 160ms ease, background 180ms ease;
+  z-index: -1;
 }
 
 .result-tabbar__item:hover {
-  color: rgba(255, 255, 255, 0.72);
-}
-
-.result-tabbar__item + .result-tabbar__item {
-  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.78);
 }
 
 .result-tabbar__item.is-active {
-  background: linear-gradient(180deg, #57060c 0%, #a9151f 52%, #d3202b 100%);
-  color: #ffe6cf;
-  box-shadow: inset 0 1px 0 rgba(255, 191, 175, 0.25);
+  color: #fff6dc;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+}
+
+.result-tabbar__item.is-active::before {
+  background: linear-gradient(90deg, #5f060c 0%, #c01926 52%, #f43240 100%);
+  opacity: 1;
+}
+
+.result-tabbar__item:not(.is-active)::before {
+  opacity: 1;
 }
 
 .result-tabbar__label {
@@ -103,22 +119,28 @@
   align-items: center;
   justify-content: space-between;
   flex-wrap: nowrap;
-  gap: clamp(10px, 2.4vw, 26px);
-  padding: clamp(6px, 1.2vw, 10px) clamp(18px, 3.2vw, 32px);
+  gap: clamp(8px, 2vw, 18px);
+  padding: clamp(4px, 0.9vw, 6px) clamp(14px, 2.4vw, 22px);
   border-radius: 9px;
   overflow: hidden;
-  min-height: clamp(46px, 6vw, 64px);
-  background: linear-gradient(90deg, #9d7c2e 0%, #c4a349 50%, #e6cf7b 100%);
-  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.48);
-  margin-inline: clamp(20px, 3vw, 36px);
+  min-height: clamp(40px, 4.2vw, 44px);
+  background: linear-gradient(
+    90deg,
+    rgba(203, 162, 82, 0) 0%,
+    rgba(203, 162, 82, 0.42) 50%,
+    rgba(203, 162, 82, 0) 100%
+  );
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.36);
+  margin-inline: clamp(18px, 2.6vw, 32px);
+  backdrop-filter: blur(5px);
 }
 
 .result-banner__surface {
   position: absolute;
   inset: -40% -20%;
-  background: radial-gradient(circle at 12% -50%, rgba(255, 255, 255, 0.45), transparent 70%),
-    radial-gradient(circle at 88% 40%, rgba(255, 248, 225, 0.32), transparent 70%);
-  opacity: 0.4;
+  background: radial-gradient(circle at 12% -50%, rgba(255, 244, 210, 0.16), transparent 70%),
+    radial-gradient(circle at 88% 40%, rgba(255, 238, 204, 0.12), transparent 70%);
+  opacity: 0.18;
   pointer-events: none;
 }
 
@@ -127,11 +149,16 @@
   top: 50%;
   left: -18%;
   width: 130%;
-  height: 96px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 243, 210, 0.22) 50%, rgba(255, 255, 255, 0.32) 100%);
+  height: 92px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 243, 214, 0.12) 0%,
+    rgba(255, 233, 196, 0.08) 50%,
+    rgba(255, 243, 214, 0.12) 100%
+  );
   transform: translateY(-50%);
-  filter: blur(22px);
-  opacity: 0.45;
+  filter: blur(28px);
+  opacity: 0.18;
   pointer-events: none;
 }
 
@@ -142,8 +169,8 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.35));
-  opacity: 0.85;
+  background: linear-gradient(90deg, rgba(255, 243, 210, 0.42), rgba(255, 243, 210, 0.08));
+  opacity: 0.6;
   pointer-events: none;
 }
 
@@ -152,8 +179,8 @@
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  border: 1px solid rgba(255, 238, 209, 0.38);
-  box-shadow: inset 0 -1px 0 rgba(84, 54, 19, 0.45);
+  border: 1px solid rgba(228, 205, 150, 0.38);
+  box-shadow: inset 0 -1px 0 rgba(84, 54, 19, 0.2);
   pointer-events: none;
 }
 
@@ -163,33 +190,33 @@
   flex: 1;
   max-width: 420px;
   text-align: left;
-  font-size: clamp(1.5rem, 3.6vw, 2.1rem);
+  font-size: clamp(0.92rem, 2.4vw, 1.22rem);
   font-weight: 700;
-  letter-spacing: 0.22em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: #fff7dc;
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
-  line-height: 1.02;
+  color: rgba(255, 248, 225, 0.92);
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
+  line-height: 1.05;
   z-index: 1;
 }
 
 .result-banner__title::before {
   content: '';
   position: absolute;
-  left: -20px;
+  left: -16px;
   top: 50%;
-  width: clamp(14px, 1.8vw, 20px);
+  width: clamp(12px, 1.6vw, 18px);
   height: 1px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 254, 240, 0.85));
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 248, 218, 0.65));
   transform: translateY(-50%);
 }
 
 .result-banner__stats {
   position: relative;
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: flex-end;
-  gap: clamp(10px, 2vw, 18px);
+  gap: clamp(8px, 1.8vw, 16px);
   margin-left: auto;
   white-space: nowrap;
   z-index: 1;
@@ -197,26 +224,26 @@
 
 .result-banner__panel {
   display: inline-flex;
-  align-items: baseline;
-  gap: clamp(6px, 1.5vw, 12px);
+  align-items: center;
+  gap: clamp(4px, 1vw, 8px);
   padding: 0;
   background: transparent;
   border: none;
 }
 
 .result-banner__panel-label {
-  font-size: 0.62rem;
-  letter-spacing: 0.24em;
+  font-size: 0.5rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(54, 35, 9, 0.7);
+  color: rgba(51, 38, 17, 0.66);
 }
 
 .result-banner__panel-value {
-  font-size: clamp(1.2rem, 2.6vw, 1.6rem);
+  font-size: clamp(0.82rem, 1.8vw, 1.08rem);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: #2b1b05;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
+  color: rgba(49, 33, 10, 0.85);
+  text-shadow: 0 1px 0 rgba(255, 245, 220, 0.28);
 }
 
 .result-header__divider {
@@ -570,22 +597,21 @@
   }
 
   .result-tabbar__item {
-    min-width: clamp(92px, 32vw, 120px);
-    padding: 0 clamp(12px, 6vw, 18px);
-    height: clamp(34px, 11vw, 40px);
-    font-size: 0.68rem;
-    letter-spacing: 0.22em;
+    padding: 0 clamp(10px, 5.4vw, 16px);
+    height: clamp(34px, 10vw, 40px);
+    font-size: 0.64rem;
+    letter-spacing: 0.16em;
   }
 
   .result-tabbar {
-    padding-inline: clamp(12px, 8vw, 20px);
+    padding-inline: clamp(10px, 7vw, 18px);
   }
 
   .result-banner {
-    padding: clamp(6px, 3.4vw, 10px) clamp(14px, 6vw, 22px);
-    min-height: clamp(44px, 12vw, 56px);
-    gap: clamp(8px, 4vw, 14px);
-    margin-inline: clamp(12px, 6vw, 24px);
+    padding: clamp(5px, 3.2vw, 8px) clamp(12px, 5.6vw, 20px);
+    min-height: clamp(40px, 11vw, 44px);
+    gap: clamp(8px, 3.8vw, 12px);
+    margin-inline: clamp(10px, 5.6vw, 20px);
   }
 
   .result-header__divider {
@@ -593,8 +619,8 @@
   }
 
   .result-banner__title {
-    font-size: clamp(1.32rem, 7vw, 1.7rem);
-    letter-spacing: 0.18em;
+    font-size: clamp(1.08rem, 6.4vw, 1.32rem);
+    letter-spacing: 0.14em;
   }
 
   .result-banner__title::before {
@@ -602,15 +628,15 @@
   }
 
   .result-banner__stats {
-    gap: clamp(6px, 4vw, 12px);
+    gap: clamp(6px, 3.6vw, 10px);
   }
 
   .result-banner__panel-label {
-    font-size: 0.56rem;
+    font-size: 0.52rem;
   }
 
   .result-banner__panel-value {
-    font-size: clamp(1rem, 5.8vw, 1.28rem);
+    font-size: clamp(0.9rem, 5.2vw, 1.12rem);
   }
 
   .result-card {


### PR DESCRIPTION
## Summary
- reshape the result scene tab bar into a full-width parallelogram layout with clear active/inactive states
- refine the gold banner with a thinner semi-transparent gradient and scaled-down typography for subdued presentation
- stabilise the tab bar and gold banner spacing so layouts hold on desktop and mobile widths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d78672f810832f8fd11132cf297097