### PR TITLE
fix: adjust intro terminal mobile layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -413,7 +413,8 @@
   flex-direction: column;
   align-items: center;
   gap: 1.75rem;
-  width: min(780px, 92vw);
+  width: 100%;
+  max-width: min(780px, 92vw);
 }
 
 .intro-terminal__logs {
@@ -424,6 +425,8 @@
 
 /* Terminal-like block for Intro */
 .terminal {
+  width: 100%;
+  max-width: min(720px, 88vw);
   margin: 0;
   padding: 0.85rem 1rem;
   border-radius: 1rem;
@@ -496,15 +499,8 @@
   text-align: center;
 }
 
-.intro-terminal__percent {
-  font-size: clamp(2.4rem, 12vw, 4.8rem);
-  font-weight: 700;
-  letter-spacing: 0.08em;
-}
-
 .intro-terminal__counts {
-  margin-top: 0.35rem;
-  font-size: 0.95rem;
+  font-size: 1.05rem;
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: rgba(205, 215, 255, 0.7);

--- a/src/scenes/IntroScene.tsx
+++ b/src/scenes/IntroScene.tsx
@@ -138,11 +138,11 @@ export const IntroScene = ({ onAdvance, reportIntroBootState }: SceneComponentPr
       {stage === 'terminal' ? (
         <div className="intro-terminal" role="status" aria-live="polite">
           <div className="intro-terminal__logs">
-              <div className="terminal" style={{ width: 'min(720px, 88vw)' }}>
-                {logs.map((line) => {
-                  if (line.kind === 'category') {
-                    return (
-                      <div
+            <div className="terminal">
+              {logs.map((line) => {
+                if (line.kind === 'category') {
+                  return (
+                    <div
                       key={line.id}
                       className={`terminal__line terminal__line--category terminal__line--${line.status}`}
                     >
@@ -150,19 +150,21 @@ export const IntroScene = ({ onAdvance, reportIntroBootState }: SceneComponentPr
                     </div>
                   )
                 }
+
                 if (line.kind === 'retry') {
                   return (
                     <div key={line.id} className="terminal__line terminal__line--retry">
                       retry x{line.attempt} → {line.label}
                     </div>
                   )
-                  }
-                  return (
-                    <div key={line.id} className="terminal__line terminal__line--missing">
-                      missing → {line.label}
-                    </div>
-                  )
-                })}
+                }
+
+                return (
+                  <div key={line.id} className="terminal__line terminal__line--missing">
+                    missing → {line.label}
+                  </div>
+                )
+              })}
                 <div className="terminal__line terminal__line--progress" aria-live="polite">
                   {progressLine}
                 </div>
@@ -170,7 +172,6 @@ export const IntroScene = ({ onAdvance, reportIntroBootState }: SceneComponentPr
             </div>
 
           <div className="intro-terminal__meter" aria-live="polite">
-            <div className="intro-terminal__percent">{percent}%</div>
             <div className="intro-terminal__counts">{loaded}/{total}</div>
           </div>
 


### PR DESCRIPTION
## Summary
- prevent the intro terminal block from overflowing on small screens by using full-width containers with viewport-based max widths
- move the terminal width constraint into CSS and drop the oversized percent indicator from the meter
- keep the counts display readable after removing the percent line

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ca58bb98832fbb8db0633458acbc