### PR TITLE
Reset journey sessions when build changes

### DIFF
--- a/src/components/BuildStamp.tsx
+++ b/src/components/BuildStamp.tsx
@@ -1,6 +1,19 @@
+import { APP_BUILD_ID } from '../constants/build'
+
 export const BuildStamp = () => (
-  <div style={{position:'fixed',left:8,top:8,fontSize:10,opacity:0.6,pointerEvents:'none',zIndex:99,color:'#cdd7ff'}}>
-    build: 2025-09-19-03
+  <div
+    style={{
+      position: 'fixed',
+      left: 8,
+      top: 8,
+      fontSize: 10,
+      opacity: 0.6,
+      pointerEvents: 'none',
+      zIndex: 99,
+      color: '#cdd7ff',
+    }}
+  >
+    build: {APP_BUILD_ID}
   </div>
 )
 

--- a/src/constants/build.ts
+++ b/src/constants/build.ts
@@ -1,0 +1,1 @@
+export const APP_BUILD_ID = '2025-09-19-03'

--- a/src/types/experience.ts
+++ b/src/types/experience.ts
@@ -3,6 +3,7 @@ import type { JourneyQuestionStyle } from './journey'
 export interface JourneySessionInfo {
   id: string
   createdAt: string
+  buildId?: string
 }
 
 export interface SaveJourneyResponsePayload {


### PR DESCRIPTION
## Summary
- add an app build ID constant and reuse it for the build stamp display
- store the build ID on journey sessions and normalize stored data with the current build
- regenerate journey sessions when the stored build differs to allow fresh responses after updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d89b1413cc832fbe1b748008d29c95