### PR TITLE
Add manual session reset control for Journeys responses

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3791,6 +3791,14 @@
   flex-wrap: wrap;
 }
 
+.journeys-card__footer-meta {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
 .journeys-card__timestamp {
   font-size: 0.78rem;
   letter-spacing: 0.1em;
@@ -3809,6 +3817,33 @@
   text-transform: uppercase;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.journeys-card__reset {
+  border: 1px solid rgba(245, 244, 255, 0.45);
+  border-radius: 999px;
+  padding: 0.6rem 1.25rem;
+  background: transparent;
+  color: rgba(245, 244, 255, 0.85);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.journeys-card__reset:hover,
+.journeys-card__reset:focus-visible {
+  border-color: rgba(245, 244, 255, 0.75);
+  color: #f5f4ff;
+  background: rgba(245, 244, 255, 0.12);
+  outline: none;
+}
+
+.journeys-card__reset:active {
+  transform: scale(0.97);
 }
 
 .journeys-card__submit:disabled {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -175,6 +175,11 @@ function App() {
     beginNewSession()
   }
 
+  const beginJourneySessionWithHistory = useCallback(() => {
+    recordSnapshot('Begin journey session')
+    beginNewSession()
+  }, [beginNewSession, recordSnapshot])
+
   const saveResponseWithHistory = useCallback(
     (payload: Parameters<typeof saveResponse>[0]) => {
       const existing = responses.find((entry) => entry.storageKey === payload.storageKey)
@@ -199,7 +204,7 @@ function App() {
     saveResponse: saveResponseWithHistory,
     setDistanceTraveled,
     journeySession: session,
-    beginJourneySession: beginNewSession,
+    beginJourneySession: beginJourneySessionWithHistory,
     reportIntroBootState: setIntroBootState,
   }
 

--- a/src/components/BuildStamp.tsx
+++ b/src/components/BuildStamp.tsx
@@ -1,6 +1,19 @@
+import { APP_BUILD_ID } from '../constants/build'
+
 export const BuildStamp = () => (
-  <div style={{position:'fixed',left:8,top:8,fontSize:10,opacity:0.6,pointerEvents:'none',zIndex:99,color:'#cdd7ff'}}>
-    build: 2025-09-19-03
+  <div
+    style={{
+      position: 'fixed',
+      left: 8,
+      top: 8,
+      fontSize: 10,
+      opacity: 0.6,
+      pointerEvents: 'none',
+      zIndex: 99,
+      color: '#cdd7ff',
+    }}
+  >
+    build: {APP_BUILD_ID}
   </div>
 )
 

--- a/src/constants/build.ts
+++ b/src/constants/build.ts
@@ -1,0 +1,1 @@
+export const APP_BUILD_ID = '2025-09-19-03'

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -241,6 +241,7 @@ const QuestionCard = ({
   onAnswerChange,
   onTextBlur,
   onSubmit,
+  onBeginNewSession,
 }: {
   step: JourneyQuestionStep
   journey: Journey
@@ -250,6 +251,7 @@ const QuestionCard = ({
   onAnswerChange?: (value: string) => void
   onTextBlur?: () => void
   onSubmit?: () => void
+  onBeginNewSession?: () => void
 }) => {
   const isChoice = step.style === 'choice'
   const recordedLabel = storedResponse?.recordedAt
@@ -261,6 +263,7 @@ const QuestionCard = ({
   const isCorrectAnswer = shouldShowQuizFeedback
     ? answerValue === step.correctAnswer
     : undefined
+  const canBeginNewSession = Boolean(onBeginNewSession) && isLocked
 
   return (
     <article
@@ -313,7 +316,18 @@ const QuestionCard = ({
                 <p className="journeys-card__answer">正解: {step.correctAnswer}</p>
               </div>
             ) : null}
-            <span className="journeys-card__timestamp">{recordedLabel}</span>
+            <div className="journeys-card__footer-meta">
+              {canBeginNewSession ? (
+                <button
+                  type="button"
+                  className="journeys-card__reset"
+                  onClick={onBeginNewSession}
+                >
+                  新規入力
+                </button>
+              ) : null}
+              <span className="journeys-card__timestamp">{recordedLabel}</span>
+            </div>
           </div>
         </>
       ) : (
@@ -345,7 +359,18 @@ const QuestionCard = ({
                 入力OK
               </button>
             ) : null}
-            <span className="journeys-card__timestamp">{recordedLabel}</span>
+            <div className="journeys-card__footer-meta">
+              {canBeginNewSession ? (
+                <button
+                  type="button"
+                  className="journeys-card__reset"
+                  onClick={onBeginNewSession}
+                >
+                  新規入力
+                </button>
+              ) : null}
+              <span className="journeys-card__timestamp">{recordedLabel}</span>
+            </div>
           </div>
         </div>
       )}
@@ -362,6 +387,7 @@ export const JourneysScene = ({
   responses,
   saveResponse,
   setDistanceTraveled,
+  beginJourneySession,
 }: SceneComponentProps) => {
   type StoryPage =
     | { kind: 'journey'; journey: Journey }
@@ -499,6 +525,11 @@ export const JourneysScene = ({
       questionType: activeQuestion.style,
     })
   }, [activeJourney, activeQuestion, draftAnswer, saveResponse, storedResponse])
+
+  const handleBeginJourneySession = useCallback(() => {
+    beginJourneySession()
+    setDraftAnswer('', { label: 'Journeys: begin new session', record: false })
+  }, [beginJourneySession, setDraftAnswer])
 
   if (!activeJourney || !activePage) {
     return (
@@ -639,6 +670,7 @@ export const JourneysScene = ({
               onAnswerChange={handleAnswerChange}
               onTextBlur={handleTextBlur}
               onSubmit={handleAnswerSubmit}
+              onBeginNewSession={handleBeginJourneySession}
             />
           ) : (
             <QuestionCard
@@ -649,6 +681,7 @@ export const JourneysScene = ({
               isLocked={isQuestionReadOnly}
               onAnswerChange={handleAnswerChange}
               onTextBlur={handleTextBlur}
+              onBeginNewSession={handleBeginJourneySession}
             />
           )}
         </div>

--- a/src/types/experience.ts
+++ b/src/types/experience.ts
@@ -3,6 +3,7 @@ import type { JourneyQuestionStyle } from './journey'
 export interface JourneySessionInfo {
   id: string
   createdAt: string
+  buildId?: string
 }
 
 export interface SaveJourneyResponsePayload {


### PR DESCRIPTION
## Summary
- add a "新規入力" action to locked Journey questions so visitors can start a fresh session
- ensure beginning a new session is tracked in history and clears draft answers
- style the new control to match existing Journey card actions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d89b1413cc832fbe1b748008d29c95