### PR TITLE
Fix quiz reset button in Journeys

### DIFF
--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -681,7 +681,6 @@ export const JourneysScene = ({
               isLocked={isQuestionReadOnly}
               onAnswerChange={handleAnswerChange}
               onTextBlur={handleTextBlur}
-              onBeginNewSession={handleBeginJourneySession}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- hide the "新規入力" control on quiz questions by omitting the begin session handler when rendering choice steps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a449ba00832f8b584d130ff23c2b