### PR TITLE
Remove spoiler exchange counts from Links and Media scenes

### DIFF
--- a/src/scenes/LinksScene.tsx
+++ b/src/scenes/LinksScene.tsx
@@ -526,11 +526,6 @@ export const LinksScene = ({ onAdvance }: SceneComponentProps) => {
         {formatNumber(count)}
       </div>
 
-      <div className="links-meta" aria-hidden>
-        <p>あなた → 彼女 {formatNumber(linkExchangeCounts.fromYou)} 件</p>
-        <p>彼女 → あなた {formatNumber(linkExchangeCounts.fromPartner)} 件</p>
-      </div>
-
       {phase !== 'play' && (
         <div
           className={`links-caption${showLines ? ' is-visible' : ''}`}

--- a/src/scenes/MediaScene.tsx
+++ b/src/scenes/MediaScene.tsx
@@ -615,11 +615,6 @@ export const MediaScene = ({ onAdvance }: SceneComponentProps) => {
         {formatNumber(count)}
       </div>
 
-      <div className="media-meta" aria-hidden>
-        <p>あなた → 彼女 {formatNumber(mediaExchangeCounts.fromYou)} 枚</p>
-        <p>彼女 → あなた {formatNumber(mediaExchangeCounts.fromPartner)} 枚</p>
-      </div>
-
       {phase !== 'play' && (
         <div className="media-caption" role="status">
           <p>一年間で送りあったメディアは</p>


### PR DESCRIPTION
## Summary
- remove the directional exchange count captions from the Links and Media scenes to avoid spoilers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8aa140630832f9a0285966175d9cd