### PR TITLE
Adjust result banner copy and responsive layout

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -118,8 +118,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  flex-wrap: wrap;
-  gap: clamp(8px, 2vw, 18px);
+  flex-wrap: nowrap;
+  gap: clamp(10px, 2vw, 20px);
   padding: clamp(4px, 0.9vw, 6px) clamp(14px, 2.4vw, 22px);
   border-radius: 9px;
   overflow: hidden;
@@ -187,17 +187,17 @@
 .result-banner__title {
   position: relative;
   margin: 0;
-  flex: 0 1 auto;
-  min-width: clamp(94px, 18vw, 140px);
+  flex: 0 0 auto;
+  min-width: 0;
   text-align: left;
-  font-size: clamp(0.88rem, 2vw, 1.16rem);
+  font-size: clamp(0.8rem, 2.2vw, 1.12rem);
   font-weight: 700;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
+  letter-spacing: clamp(0.08em, 0.8vw, 0.16em);
   color: rgba(255, 248, 225, 0.92);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.24);
   line-height: 1.1;
   z-index: 1;
+  white-space: nowrap;
 }
 
 .result-banner__title::before {
@@ -217,38 +217,76 @@
   align-items: center;
   justify-content: flex-end;
   flex: 1 1 auto;
-  gap: clamp(10px, 2.2vw, 22px);
+  min-width: 0;
+  gap: clamp(8px, 1.8vw, 18px);
   margin-left: auto;
   z-index: 1;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 
 .result-banner__panel {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: clamp(2px, 0.6vw, 4px);
+  display: inline-flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: clamp(4px, 1vw, 8px);
   padding: 0;
   background: transparent;
   border: none;
-  min-width: clamp(120px, 22vw, 200px);
+  min-width: 0;
+  white-space: nowrap;
 }
 
 .result-banner__panel-label {
-  font-size: clamp(0.48rem, 1.2vw, 0.62rem);
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: rgba(51, 38, 17, 0.66);
-  line-height: 1.4;
+  font-size: clamp(0.52rem, 1.6vw, 0.68rem);
+  letter-spacing: clamp(0.04em, 0.6vw, 0.1em);
+  text-transform: none;
+  color: rgba(51, 38, 17, 0.68);
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .result-banner__panel-value {
-  font-size: clamp(0.9rem, 2vw, 1.18rem);
+  font-size: clamp(0.86rem, 2.4vw, 1.14rem);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   color: rgba(49, 33, 10, 0.85);
   text-shadow: 0 1px 0 rgba(255, 245, 220, 0.28);
-  line-height: 1.15;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+@media (max-width: 520px) {
+  .result-banner {
+    padding: clamp(4px, 1.4vw, 8px) clamp(12px, 3.6vw, 18px);
+    gap: clamp(6px, 1.6vw, 12px);
+  }
+
+  .result-banner__title::before {
+    left: -12px;
+    width: clamp(8px, 2vw, 14px);
+  }
+
+  .result-banner__title {
+    font-size: clamp(0.78rem, 4vw, 0.98rem);
+    letter-spacing: clamp(0.05em, 0.8vw, 0.12em);
+  }
+
+  .result-banner__stats {
+    gap: clamp(6px, 1.2vw, 10px);
+  }
+
+  .result-banner__panel {
+    gap: clamp(3px, 1.2vw, 6px);
+  }
+
+  .result-banner__panel-label {
+    font-size: clamp(0.5rem, 2.8vw, 0.62rem);
+    letter-spacing: clamp(0.03em, 0.6vw, 0.08em);
+  }
+
+  .result-banner__panel-value {
+    font-size: clamp(0.82rem, 3.6vw, 1.02rem);
+  }
 }
 
 .result-header__divider {

--- a/src/scenes/ResultScene.tsx
+++ b/src/scenes/ResultScene.tsx
@@ -217,7 +217,7 @@ const buildViewData = (payload?: ResultPayload): ResultViewData => {
   })
 
   return {
-    resultTitle: payload?.resultTitle?.trim() || 'forever',
+    resultTitle: payload?.resultTitle?.trim() || 'Forever',
     teamRank: {
       text: teamRankValue ? `${teamRankValue}位` : '— 位',
       ariaLabel: `部隊の順位 ${teamRankValue ?? '—'} 位`,


### PR DESCRIPTION
## Summary
- update the result scene banner title default to "Forever"
- refine the banner typography and spacing so the title and stats stay on a single line on mobile widths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8b8e89310832faa6372f5f1962277