### PR TITLE
Refine result banner contrast and mobile card stacking

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -229,9 +229,11 @@
   flex-direction: row;
   align-items: baseline;
   gap: clamp(4px, 1vw, 8px);
-  padding: 0;
-  background: transparent;
-  border: none;
+  padding: clamp(4px, 1vw, 6px) clamp(6px, 1.4vw, 10px);
+  background: linear-gradient(145deg, rgba(23, 15, 2, 0.8), rgba(15, 9, 0, 0.55));
+  border-radius: 10px;
+  border: 1px solid rgba(255, 240, 206, 0.32);
+  box-shadow: inset 0 1px 0 rgba(255, 252, 232, 0.2), 0 4px 10px rgba(0, 0, 0, 0.3);
   min-width: 0;
   white-space: nowrap;
 }
@@ -240,17 +242,18 @@
   font-size: clamp(0.52rem, 1.6vw, 0.68rem);
   letter-spacing: clamp(0.04em, 0.6vw, 0.1em);
   text-transform: none;
-  color: rgba(51, 38, 17, 0.68);
+  color: rgba(255, 250, 232, 0.9);
   line-height: 1.2;
   white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(20, 8, 1, 0.56);
 }
 
 .result-banner__panel-value {
   font-size: clamp(0.86rem, 2.4vw, 1.14rem);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
-  color: rgba(49, 33, 10, 0.85);
-  text-shadow: 0 1px 0 rgba(255, 245, 220, 0.28);
+  color: #fffdf3;
+  text-shadow: 0 2px 4px rgba(15, 7, 1, 0.5);
   line-height: 1.1;
   white-space: nowrap;
 }
@@ -292,6 +295,52 @@
   .result-banner__panel-value {
     font-size: clamp(0.78rem, 3.4vw, 0.98rem);
     line-height: 1.05;
+  }
+}
+
+@media (max-width: 820px) {
+  .result-banner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: clamp(10px, 2.8vw, 18px);
+  }
+
+  .result-banner__stats {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: clamp(8px, 3.2vw, 14px);
+  }
+
+  .result-banner__panel {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: clamp(2px, 1.2vw, 6px);
+    padding: clamp(6px, 2vw, 10px) clamp(10px, 3vw, 14px);
+    border-radius: 12px;
+    background: linear-gradient(160deg, rgba(26, 16, 2, 0.78), rgba(14, 8, 0, 0.6));
+    backdrop-filter: blur(6px);
+  }
+
+  .result-banner__panel-label {
+    text-align: left;
+  }
+
+  .result-banner__panel-value {
+    font-size: clamp(0.82rem, 3vw, 1.08rem);
+  }
+
+  .result-card {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'body'
+      'image';
+    gap: clamp(16px, 5vw, 24px);
+  }
+
+  .result-card__image {
+    min-height: clamp(210px, 58vw, 280px);
+    justify-self: stretch;
   }
 }
 
@@ -338,6 +387,7 @@
   position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) clamp(110px, 16vw, 130px);
+  grid-template-areas: 'body image';
   gap: clamp(14px, 2.6vw, 24px);
   padding: clamp(18px, 2.8vw, 26px);
   border-radius: 14px;
@@ -371,6 +421,7 @@
   gap: clamp(12px, 2.5vw, 18px);
   min-width: 0;
   z-index: 1;
+  grid-area: body;
 }
 
 .result-card__header {
@@ -438,6 +489,7 @@
   align-items: stretch;
   justify-content: center;
   z-index: 1;
+  grid-area: image;
 }
 
 .result-card__image::before {
@@ -697,7 +749,8 @@
 
   .result-card {
     padding: clamp(16px, 6vw, 22px);
-    grid-template-columns: minmax(0, 1fr) clamp(75px, 32vw, 95px);
+    grid-template-columns: minmax(0, 1fr);
+    gap: clamp(16px, 6vw, 22px);
   }
 
   .result-card__image {
@@ -722,13 +775,7 @@
 
 @media (max-width: 520px) {
   .result-card {
-    grid-template-columns: minmax(0, 1fr);
     gap: clamp(14px, 6vw, 20px);
-  }
-
-  .result-card__body,
-  .result-card__image {
-    grid-column: 1;
   }
 
   .result-card__image {


### PR DESCRIPTION
## Summary
- add a tinted container and brighter typography to the result banner stats for better contrast on the gold backdrop
- switch the result player card grid to named areas so the image stacks beneath the stats on narrow viewports without shrinking the card width

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8d5b7f6cc832fa1ee2462513289fd