### PR TITLE
Adjust result player card image width

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -386,7 +386,7 @@
 .result-card {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) clamp(220px, 46%, 420px);
+  grid-template-columns: minmax(0, 1fr) minmax(260px, min(52vw, 520px));
   grid-template-areas: 'body image';
   gap: clamp(14px, 2.6vw, 24px);
   padding: clamp(18px, 2.8vw, 26px);
@@ -651,7 +651,7 @@
 
 @media (max-width: 1024px) {
   .result-card {
-    grid-template-columns: minmax(0, 1fr) clamp(220px, 48vw, 360px);
+    grid-template-columns: minmax(0, 1fr) minmax(240px, min(56vw, 460px));
   }
 }
 
@@ -674,7 +674,7 @@
   .result-card {
     flex: 0 0 100%;
     max-width: 100%;
-    grid-template-columns: minmax(0, 1fr) clamp(220px, 64vw, 340px);
+    grid-template-columns: minmax(0, 1fr) minmax(240px, min(70vw, 420px));
   }
 
   .result-card:hover,


### PR DESCRIPTION
## Summary
- widen the result player card image column so it can expand closer to half of the viewport on large screens
- update responsive breakpoints to preserve the wider image presentation on tablets and desktops

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8ec3e6804832faf6f88431f9f6d0a