### PR TITLE
Add top and bottom highlights to result banner

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -177,10 +177,12 @@
 .result-banner::after {
   content: '';
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  border: 1px solid rgba(228, 205, 150, 0.38);
-  box-shadow: inset 0 -1px 0 rgba(84, 54, 19, 0.2);
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(68, 43, 12, 0.16), rgba(210, 168, 96, 0.38), rgba(68, 43, 12, 0.16));
+  opacity: 0.6;
   pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- add a bottom accent line to the result banner so the inner frame only appears along the top and bottom edges

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8faf3bfc8832fa7d80d986d91d523