### PR TITLE
Adjust result banner layout

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -220,7 +220,7 @@
   justify-content: flex-end;
   flex: 1 1 auto;
   min-width: 0;
-  gap: clamp(8px, 1.8vw, 18px);
+  gap: clamp(10px, 2vw, 20px);
   margin-left: auto;
   z-index: 1;
   flex-wrap: nowrap;
@@ -228,14 +228,14 @@
 
 .result-banner__panel {
   display: inline-flex;
-  flex-direction: row;
-  align-items: baseline;
-  gap: clamp(4px, 1vw, 8px);
-  padding: clamp(4px, 1vw, 6px) clamp(6px, 1.4vw, 10px);
-  background: linear-gradient(145deg, rgba(23, 15, 2, 0.8), rgba(15, 9, 0, 0.55));
-  border-radius: 10px;
-  border: 1px solid rgba(255, 240, 206, 0.32);
-  box-shadow: inset 0 1px 0 rgba(255, 252, 232, 0.2), 0 4px 10px rgba(0, 0, 0, 0.3);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: clamp(2px, 0.6vw, 4px);
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
   min-width: 0;
   white-space: nowrap;
 }
@@ -245,18 +245,18 @@
   letter-spacing: clamp(0.04em, 0.6vw, 0.1em);
   text-transform: none;
   color: rgba(255, 250, 232, 0.9);
-  line-height: 1.2;
+  line-height: 1.1;
   white-space: nowrap;
-  text-shadow: 0 1px 2px rgba(20, 8, 1, 0.56);
+  text-shadow: 0 1px 2px rgba(20, 8, 1, 0.36);
 }
 
 .result-banner__panel-value {
-  font-size: clamp(0.86rem, 2.4vw, 1.14rem);
+  font-size: clamp(0.86rem, 2.2vw, 1.08rem);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   color: #fffdf3;
-  text-shadow: 0 2px 4px rgba(15, 7, 1, 0.5);
-  line-height: 1.1;
+  text-shadow: 0 2px 4px rgba(15, 7, 1, 0.45);
+  line-height: 1.05;
   white-space: nowrap;
 }
 
@@ -277,61 +277,20 @@
   }
 
   .result-banner__stats {
-    gap: clamp(4px, 1vw, 8px);
-  }
-
-  .result-banner__panel {
-    flex-direction: column;
-    align-items: flex-end;
-    gap: clamp(2px, 0.9vw, 4px);
+    gap: clamp(6px, 1.6vw, 10px);
   }
 
   .result-banner__panel-label {
-    font-size: clamp(0.48rem, 2.6vw, 0.6rem);
-    letter-spacing: clamp(0.02em, 0.5vw, 0.06em);
-    line-height: 1.1;
-    white-space: normal;
-    text-align: right;
+    font-size: clamp(0.48rem, 2.4vw, 0.6rem);
+    letter-spacing: clamp(0.03em, 0.5vw, 0.06em);
   }
 
   .result-banner__panel-value {
-    font-size: clamp(0.78rem, 3.4vw, 0.98rem);
-    line-height: 1.05;
+    font-size: clamp(0.78rem, 3.2vw, 0.96rem);
   }
 }
 
 @media (max-width: 820px) {
-  .result-banner {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: clamp(10px, 2.8vw, 18px);
-  }
-
-  .result-banner__stats {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: clamp(8px, 3.2vw, 14px);
-  }
-
-  .result-banner__panel {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: clamp(2px, 1.2vw, 6px);
-    padding: clamp(6px, 2vw, 10px) clamp(10px, 3vw, 14px);
-    border-radius: 12px;
-    background: linear-gradient(160deg, rgba(26, 16, 2, 0.78), rgba(14, 8, 0, 0.6));
-    backdrop-filter: blur(6px);
-  }
-
-  .result-banner__panel-label {
-    text-align: left;
-  }
-
-  .result-banner__panel-value {
-    font-size: clamp(0.82rem, 3vw, 1.08rem);
-  }
-
   .result-card {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:


### PR DESCRIPTION
## Summary
- remove the boxed styling from the result banner stats so the labels render directly on the gold strip
- keep the result title and both team stats aligned on a single row across all breakpoints
- tune typography spacing to keep the banner compact after the layout changes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d913458eec832f9ff0d70c48966815