### PR TITLE
Adjust result banner spacing on mobile

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -263,7 +263,10 @@
 @media (max-width: 520px) {
   .result-banner {
     padding: clamp(4px, 1.4vw, 8px) clamp(12px, 3.6vw, 18px);
-    gap: clamp(6px, 1.6vw, 12px);
+    gap: clamp(6px, 1.8vw, 14px);
+    flex-wrap: wrap;
+    row-gap: clamp(8px, 2.4vw, 16px);
+    align-items: flex-start;
   }
 
   .result-banner__title::before {
@@ -272,21 +275,30 @@
   }
 
   .result-banner__title {
-    font-size: clamp(0.6rem, 3.2vw, 0.82rem);
-    letter-spacing: clamp(0.03em, 0.5vw, 0.08em);
+    flex: 1 1 100%;
+    font-size: clamp(0.56rem, 2.8vw, 0.72rem);
+    letter-spacing: clamp(0.024em, 0.46vw, 0.06em);
   }
 
   .result-banner__stats {
-    gap: clamp(10px, 2.4vw, 18px);
+    flex: 1 1 100%;
+    gap: clamp(10px, 3vw, 20px);
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .result-banner__panel {
+    flex: 1 1 0;
+    min-width: min(120px, 48%);
   }
 
   .result-banner__panel-label {
-    font-size: clamp(0.42rem, 2vw, 0.54rem);
-    letter-spacing: clamp(0.02em, 0.4vw, 0.05em);
+    font-size: clamp(0.4rem, 1.9vw, 0.52rem);
+    letter-spacing: clamp(0.018em, 0.36vw, 0.05em);
   }
 
   .result-banner__panel-value {
-    font-size: clamp(0.66rem, 2.6vw, 0.84rem);
+    font-size: clamp(0.6rem, 2.3vw, 0.76rem);
     font-weight: 600;
   }
 }


### PR DESCRIPTION
## Summary
- allow the result banner to wrap and align content cleanly on small screens
- tune mobile font sizing for the banner title, rank, and days to preserve readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d925f22c9c832fa6cfa6346a23531e