### PR TITLE
Update Prologue scene imagery

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2701,12 +2701,22 @@
 
 .prologue__backdrop--self {
   background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
-    url('/images/prologue-self-placeholder.svg');
+    url('/images/prologue/Generated Image September 26, 2025 - 2_48AM.png');
+}
+
+.prologue__backdrop--self.is-speaking {
+  background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
+    url('/images/prologue/Generated Image September 26, 2025 - 2_55AM.png');
 }
 
 .prologue__backdrop--partner {
   background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
-    url('/images/prologue-partner-placeholder.svg');
+    url('/images/prologue/Generated Image September 26, 2025 - 3_34AM.png');
+}
+
+.prologue__backdrop--partner.is-speaking {
+  background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
+    url('/images/prologue/Generated Image September 26, 2025 - 3_37AM.png');
 }
 
 .prologue__backdrop-overlay {

--- a/src/scenes/PrologueScene.tsx
+++ b/src/scenes/PrologueScene.tsx
@@ -7,12 +7,23 @@ import { useActionHistory } from '../history/ActionHistoryContext'
 const SPEAKER_PROFILES = {
   self: {
     name: 'libft',
-    avatar: '/images/prologue/Generated Image September 26, 2025 - 2_48AM.png',
+    avatars: {
+      idle: '/images/prologue/Generated Image September 26, 2025 - 2_48AM.png',
+      speaking: '/images/prologue/Generated Image September 26, 2025 - 2_55AM.png',
+    },
   },
   partner: {
     name: 'れおん',
-    avatar: '/images/prologue/Generated Image September 26, 2025 - 3_37AM.png',
+    avatars: {
+      idle: '/images/prologue/Generated Image September 26, 2025 - 3_34AM.png',
+      speaking: '/images/prologue/Generated Image September 26, 2025 - 3_37AM.png',
+    },
   },
+} as const
+
+const SERVER_PROFILE = {
+  name: 'NESSI',
+  avatar: '/images/prologue/IMG_nessi.jpeg',
 } as const
 
 const FALLBACK_AVATAR_SRC = '/images/gimmie-placeholder.svg'
@@ -33,8 +44,27 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
   const [activeBackdrop, setActiveBackdrop] = useState<'self' | 'partner'>(getInitialSpeaker)
   const [activeSpeaker, setActiveSpeaker] = useState<'self' | 'partner'>(getInitialSpeaker)
   const { record } = useActionHistory()
-  const currentSpeakerProfile = SPEAKER_PROFILES[activeSpeaker]
   const showCallStatus = activeIndex === 0
+  const activeSpeakerProfile = SPEAKER_PROFILES[activeSpeaker]
+  const isSelfLine = currentLine?.variant === 'self'
+  const isPartnerLine = currentLine?.variant === 'partner'
+  const isSystemLine = currentLine?.variant === 'system'
+
+  const displayName = isSystemLine
+    ? SERVER_PROFILE.name
+    : isSelfLine
+    ? SPEAKER_PROFILES.self.name
+    : isPartnerLine
+    ? SPEAKER_PROFILES.partner.name
+    : activeSpeakerProfile.name
+
+  const displayAvatarSrc = isSystemLine
+    ? SERVER_PROFILE.avatar
+    : isSelfLine
+    ? SPEAKER_PROFILES.self.avatars.speaking
+    : isPartnerLine
+    ? SPEAKER_PROFILES.partner.avatars.speaking
+    : activeSpeakerProfile.avatars.idle
 
   useEffect(() => {
     if (currentLine?.variant === 'self' || currentLine?.variant === 'partner') {
@@ -90,12 +120,12 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
         <div
           className={`prologue__backdrop prologue__backdrop--self ${
             activeBackdrop === 'self' ? 'is-active' : ''
-          }`}
+          } ${isSelfLine ? 'is-speaking' : ''}`}
         />
         <div
           className={`prologue__backdrop prologue__backdrop--partner ${
             activeBackdrop === 'partner' ? 'is-active' : ''
-          }`}
+          } ${isPartnerLine ? 'is-speaking' : ''}`}
         />
         <div className="prologue__backdrop-overlay" />
       </div>
@@ -104,15 +134,15 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
           <div className="prologue__call-id">
             <div className="prologue__call-avatar">
               <img
-                src={currentSpeakerProfile.avatar}
-                alt={`${currentSpeakerProfile.name}のアイコン`}
+                src={displayAvatarSrc}
+                alt={`${displayName}のアイコン`}
                 onError={handleAvatarError}
                 loading="lazy"
               />
             </div>
             <div>
               <p className="prologue__call-label">
-                {currentSpeakerProfile.name} — GIMMIE X GIMMIE
+                {displayName} — GIMMIE X GIMMIE
               </p>
               {showCallStatus ? (
                 <p className="prologue__call-status">RTC接続中</p>


### PR DESCRIPTION
## Summary
- replace the Prologue scene backdrops with the newly added character artwork
- swap the call avatar logic to use mouth-open portraits when characters speak and the server icon for system lines
- surface the appropriate speaking state in the backdrop animations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9653872a0832f90eae8f9897743a1