### PR TITLE
Fix Journeys quiz correct answer mismatch

### DIFF
--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -65,7 +65,7 @@ const newJourneyDefinitions: JourneyInput[] = [
           '3,ローソン',
           '4,ミニストップ',
         ],
-        correctAnswer: '１のセブンイレブン',
+        correctAnswer: '1,セブンイレブン',
         readonlyAfterSave: true,
       },
       {


### PR DESCRIPTION
## Summary
- align the Journeys quiz correct answer string with the displayed option to prevent incorrect "残念" feedback

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d97334ad20832fb1f987417249f1d4