### PR TITLE
Add scanned letter reveal experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4377,6 +4377,16 @@
   pointer-events: none;
 }
 
+.letter-pack__letter[data-interactive='true'] {
+  pointer-events: auto;
+  cursor: pointer;
+}
+
+.letter-pack__letter[data-interactive='true']:focus-visible {
+  outline: 2px solid rgba(163, 174, 255, 0.85);
+  outline-offset: 4px;
+}
+
 .letter-pack__letter img {
   width: 100%;
   height: 100%;

--- a/src/scenes/LetterScene.css
+++ b/src/scenes/LetterScene.css
@@ -1,0 +1,74 @@
+.letter-scene__viewer {
+  margin-top: clamp(24px, 6vw, 52px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(12px, 3vw, 24px);
+  text-align: center;
+  color: rgba(245, 244, 255, 0.85);
+}
+
+.letter-scene__instruction {
+  margin: 0;
+  max-width: min(520px, 90%);
+  font-size: clamp(0.85rem, 1.8vw, 1rem);
+  line-height: 1.7;
+}
+
+.letter-scene__controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: clamp(12px, 3vw, 24px);
+}
+
+.letter-scene__status {
+  min-width: 150px;
+  letter-spacing: 0.08em;
+  font-size: clamp(0.82rem, 1.6vw, 0.95rem);
+  color: rgba(202, 212, 255, 0.85);
+}
+
+.letter-scene__button {
+  appearance: none;
+  border: 1px solid rgba(163, 174, 255, 0.35);
+  border-radius: 999px;
+  background: rgba(16, 21, 55, 0.65);
+  color: rgba(245, 244, 255, 0.92);
+  padding: 0.5rem 1.3rem;
+  font-size: clamp(0.8rem, 1.6vw, 0.95rem);
+  letter-spacing: 0.08em;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.letter-scene__button:hover:not(:disabled) {
+  background: rgba(24, 32, 72, 0.72);
+  border-color: rgba(202, 212, 255, 0.6);
+  transform: translateY(-1px);
+  box-shadow: 0 8px 16px rgba(12, 18, 48, 0.25);
+}
+
+.letter-scene__button:focus-visible {
+  outline: 2px solid rgba(163, 174, 255, 0.85);
+  outline-offset: 3px;
+}
+
+.letter-scene__button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.letter-scene__button--secondary {
+  background: rgba(20, 28, 68, 0.55);
+  border-color: rgba(163, 174, 255, 0.25);
+}
+
+.letter-scene__button--secondary:hover:not(:disabled) {
+  background: rgba(30, 38, 86, 0.7);
+  border-color: rgba(202, 212, 255, 0.45);
+}

--- a/src/scenes/LetterScene.tsx
+++ b/src/scenes/LetterScene.tsx
@@ -1,15 +1,38 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { LetterExperience, type InteractionStage } from '../components/LetterExperience'
 import { SceneLayout } from '../components/SceneLayout'
 import type { SceneComponentProps } from '../types/scenes'
 import { useActionHistory } from '../history/ActionHistoryContext'
 
+import './LetterScene.css'
+
+const LETTER_ENVELOPE_IMAGE = {
+  src: '/images/letters/20250929022653_005.jpg',
+  alt: '手紙が入った封筒のスキャン画像',
+}
+
+const LETTER_PAGE_IMAGES = [
+  { src: '/images/letters/20250929022653_001.jpg', alt: '手紙の1枚目' },
+  { src: '/images/letters/20250929022653_002.jpg', alt: '手紙の2枚目' },
+  { src: '/images/letters/20250929022653_003.jpg', alt: '手紙の3枚目' },
+  { src: '/images/letters/20250929022653_004.jpg', alt: '手紙の4枚目' },
+]
+
 export const LetterScene = ({ onAdvance }: SceneComponentProps) => {
   const [canAdvance, setCanAdvance] = useState(false)
+  const [isRevealed, setIsRevealed] = useState(false)
+  const [isLetterOpen, setIsLetterOpen] = useState(false)
+  const [letterPageIndex, setLetterPageIndex] = useState(0)
   const { record } = useActionHistory()
 
   const handleStageChange = useCallback((stage: InteractionStage) => {
+    setIsRevealed(stage === 'revealed')
+    if (stage !== 'revealed') {
+      setIsLetterOpen(false)
+      setLetterPageIndex(0)
+    }
+
     setCanAdvance((prev) => {
       const next = stage === 'revealed'
       if (next === prev) {
@@ -22,7 +45,76 @@ export const LetterScene = ({ onAdvance }: SceneComponentProps) => {
     })
   }, [record])
 
+  const pageCount = LETTER_PAGE_IMAGES.length
+  const hasPages = pageCount > 0
+
+  const handleLetterInteraction = useCallback(() => {
+    if (!isRevealed || !hasPages) {
+      return
+    }
+
+    if (!isLetterOpen) {
+      setIsLetterOpen(true)
+      setLetterPageIndex(0)
+      return
+    }
+
+    setLetterPageIndex((index) => (index + 1) % pageCount)
+  }, [hasPages, isLetterOpen, isRevealed, pageCount])
+
+  const handleNextPage = useCallback(() => {
+    if (!hasPages) {
+      return
+    }
+
+    if (!isLetterOpen) {
+      setIsLetterOpen(true)
+      setLetterPageIndex(0)
+      return
+    }
+
+    setLetterPageIndex((index) => (index + 1) % pageCount)
+  }, [hasPages, isLetterOpen, pageCount])
+
+  const handlePrevPage = useCallback(() => {
+    if (!isLetterOpen || !hasPages) {
+      return
+    }
+
+    setLetterPageIndex((index) => (index - 1 + pageCount) % pageCount)
+  }, [hasPages, isLetterOpen, pageCount])
+
+  const handleCloseLetter = useCallback(() => {
+    setIsLetterOpen(false)
+    setLetterPageIndex(0)
+  }, [])
+
+  const currentLetterImage = useMemo(() => {
+    if (!isRevealed) {
+      return undefined
+    }
+
+    if (!isLetterOpen || !hasPages) {
+      return LETTER_ENVELOPE_IMAGE
+    }
+
+    return LETTER_PAGE_IMAGES[letterPageIndex] ?? LETTER_PAGE_IMAGES[0]
+  }, [hasPages, isLetterOpen, isRevealed, letterPageIndex])
+
+  const letterActionLabel = useMemo(() => {
+    if (!isRevealed) {
+      return undefined
+    }
+
+    if (!isLetterOpen || !hasPages) {
+      return '封筒を開いて手紙を表示'
+    }
+
+    return '手紙の次のページを表示'
+  }, [hasPages, isLetterOpen, isRevealed])
+
   const advanceHandler = canAdvance ? onAdvance : undefined
+  const pageNumber = hasPages ? letterPageIndex + 1 : 0
 
   return (
     <SceneLayout
@@ -30,7 +122,51 @@ export const LetterScene = ({ onAdvance }: SceneComponentProps) => {
       onAdvance={advanceHandler}
       advanceLabel="Resultへ"
     >
-      <LetterExperience onStageChange={handleStageChange} />
+      <LetterExperience
+        onStageChange={handleStageChange}
+        letterImage={currentLetterImage}
+        onLetterClick={handleLetterInteraction}
+        letterActionLabel={letterActionLabel}
+      />
+      {isRevealed && (
+        <div className="letter-scene__viewer" role="group" aria-label="手紙の表示コントロール">
+          <p className="letter-scene__instruction">
+            {isLetterOpen && hasPages
+              ? '画像をタップするかボタンでページをめくれます。'
+              : '封筒をタップすると中の手紙を表示します。'}
+          </p>
+          <div className="letter-scene__controls">
+            <button
+              type="button"
+              className="letter-scene__button"
+              onClick={handlePrevPage}
+              disabled={!isLetterOpen || !hasPages}
+            >
+              前のページ
+            </button>
+            <span className="letter-scene__status" role="status" aria-live="polite">
+              {isLetterOpen && hasPages ? `ページ ${pageNumber} / ${pageCount}` : '封筒を表示中'}
+            </span>
+            <button
+              type="button"
+              className="letter-scene__button"
+              onClick={handleNextPage}
+              disabled={!hasPages}
+            >
+              {isLetterOpen && hasPages ? '次のページ' : '封筒を開く'}
+            </button>
+          </div>
+          {isLetterOpen && hasPages && (
+            <button
+              type="button"
+              className="letter-scene__button letter-scene__button--secondary"
+              onClick={handleCloseLetter}
+            >
+              封筒に戻す
+            </button>
+          )}
+        </div>
+      )}
     </SceneLayout>
   )
 }


### PR DESCRIPTION
## Summary
- LetterScene に封筒とスキャンした手紙の画像を読み込み、ページ送りができる表示を追加
- LetterExperience に開封後の封筒・手紙画像を操作できるアクセシビリティ対応を実装
- LetterScene の案内と操作ボタン向けのスタイルを作成

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9756c0284832faf5f21db6fa57a4e