### PR TITLE
Fix letter visibility on small screens

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4624,6 +4624,18 @@
   box-shadow: 0 42px 68px rgba(12, 18, 48, 0.28);
 }
 
+@media (max-width: 640px) {
+  .letter-experience--revealed .letter-pack {
+    --letter-floating-offset: clamp(-14%, -18%, -12%);
+    --letter-floating-scale: 1.05;
+  }
+
+  .letter-pack__letter[data-open='true'] {
+    --letter-floating-offset: clamp(-22%, -28%, -18%);
+    --letter-floating-scale: 1.08;
+  }
+}
+
 .letter-pack__letter-overlay {
   position: absolute;
   inset: 0;


### PR DESCRIPTION
## Summary
- lower the floating offset and scale of the revealed letter on narrow viewports so the scan stays within frame
- ease the open state transform on phones to prevent the letter image from translating out of view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d99f5e0918832f85f3a4e4c140f445