### PR TITLE
Fix intro preloader asset base path handling

### DIFF
--- a/src/data/preloadManifest.ts
+++ b/src/data/preloadManifest.ts
@@ -1,6 +1,7 @@
 import { journeys } from './journeys'
 import { meetupPages } from './meetups'
 import { resultLegends } from './result'
+import { resolveAssetPath } from '../utils/assetPaths'
 
 export type PreloadAssetType = 'image' | 'json' | 'audio'
 
@@ -65,12 +66,13 @@ const makeAssets = (options: {
   const { urls, category, type, priority } = options
   const out: PreloadAsset[] = []
   for (const url of urls) {
+    const resolvedUrl = resolveAssetPath(url)
     out.push({
-      id: createAssetId(category, url),
-      url,
+      id: createAssetId(category, resolvedUrl),
+      url: resolvedUrl,
       type,
       category,
-      label: toLabel(url),
+      label: toLabel(resolvedUrl),
       priority,
     })
   }

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -11,6 +11,7 @@ import type {
 } from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
 import { useHistoryTrackedState } from '../history/useHistoryTrackedState'
+import { resolveAssetPath } from '../utils/assetPaths'
 
 const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
   year: 'numeric',
@@ -76,16 +77,6 @@ const toRoutePath = (points: JourneyCoordinate[]): string => {
   if (!points.length) return ''
   const [first, ...rest] = points
   return rest.reduce((acc, point) => `${acc} L ${point[0]} ${point[1]}`, `M ${first[0]} ${first[1]}`)
-}
-
-const resolveAssetPath = (path: string): string => {
-  if (!path) return path
-  if (path.startsWith('data:')) return path
-  if (/^(?:https?:)?\/\//.test(path)) return path
-  const base = import.meta.env.BASE_URL ?? '/'
-  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`
-  return `${sanitizedBase}${normalizedPath}`
 }
 
 const JourneyRouteMap = ({ step }: { step: JourneyMoveStep }) => {

--- a/src/utils/assetPaths.ts
+++ b/src/utils/assetPaths.ts
@@ -1,0 +1,10 @@
+export const resolveAssetPath = (path: string): string => {
+  if (!path) return path
+  if (path.startsWith('data:')) return path
+  if (/^(?:https?:)?\/\//.test(path)) return path
+
+  const base = import.meta.env.BASE_URL ?? '/'
+  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${sanitizedBase}${normalizedPath}`
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to resolve asset URLs against the configured base path
- reuse the helper in the journeys scene and preloader manifest so local images resolve under GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a2256888832f90da854e899fb3fc