### PR TITLE
Fix letter scene image paths for GitHub Pages base URL

### DIFF
--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { SceneLayout } from '../components/SceneLayout'
+import { resolveAssetPath } from '../utils/resolveAssetPath'
 import type {
   Journey,
   JourneyCoordinate,
@@ -76,16 +77,6 @@ const toRoutePath = (points: JourneyCoordinate[]): string => {
   if (!points.length) return ''
   const [first, ...rest] = points
   return rest.reduce((acc, point) => `${acc} L ${point[0]} ${point[1]}`, `M ${first[0]} ${first[1]}`)
-}
-
-const resolveAssetPath = (path: string): string => {
-  if (!path) return path
-  if (path.startsWith('data:')) return path
-  if (/^(?:https?:)?\/\//.test(path)) return path
-  const base = import.meta.env.BASE_URL ?? '/'
-  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`
-  return `${sanitizedBase}${normalizedPath}`
 }
 
 const JourneyRouteMap = ({ step }: { step: JourneyMoveStep }) => {

--- a/src/scenes/LetterScene.tsx
+++ b/src/scenes/LetterScene.tsx
@@ -4,19 +4,20 @@ import { LetterExperience, type InteractionStage } from '../components/LetterExp
 import { SceneLayout } from '../components/SceneLayout'
 import type { SceneComponentProps } from '../types/scenes'
 import { useActionHistory } from '../history/ActionHistoryContext'
+import { resolveAssetPath } from '../utils/resolveAssetPath'
 
 import './LetterScene.css'
 
 const LETTER_ENVELOPE_IMAGE = {
-  src: '/images/letters/20250929022653_005.jpg',
+  src: resolveAssetPath('/images/letters/20250929022653_005.jpg'),
   alt: '手紙が入った封筒のスキャン画像',
 }
 
 const LETTER_PAGE_IMAGES = [
-  { src: '/images/letters/20250929022653_001.jpg', alt: '手紙の1枚目' },
-  { src: '/images/letters/20250929022653_002.jpg', alt: '手紙の2枚目' },
-  { src: '/images/letters/20250929022653_003.jpg', alt: '手紙の3枚目' },
-  { src: '/images/letters/20250929022653_004.jpg', alt: '手紙の4枚目' },
+  { src: resolveAssetPath('/images/letters/20250929022653_001.jpg'), alt: '手紙の1枚目' },
+  { src: resolveAssetPath('/images/letters/20250929022653_002.jpg'), alt: '手紙の2枚目' },
+  { src: resolveAssetPath('/images/letters/20250929022653_003.jpg'), alt: '手紙の3枚目' },
+  { src: resolveAssetPath('/images/letters/20250929022653_004.jpg'), alt: '手紙の4枚目' },
 ]
 
 export const LetterScene = ({ onAdvance }: SceneComponentProps) => {

--- a/src/utils/resolveAssetPath.ts
+++ b/src/utils/resolveAssetPath.ts
@@ -1,0 +1,12 @@
+export function resolveAssetPath(path: string): string
+export function resolveAssetPath(path: undefined): undefined
+export function resolveAssetPath(path?: string): string | undefined {
+  if (!path) return path
+  if (path.startsWith('data:')) return path
+  if (/^(?:https?:)?\/\//.test(path)) return path
+
+  const base = import.meta.env.BASE_URL ?? '/'
+  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${sanitizedBase}${normalizedPath}`
+}


### PR DESCRIPTION
## Summary
- add a shared resolveAssetPath helper that prefixes asset URLs with the configured base path
- update the letter scene to load envelope and page scans through the helper so GitHub Pages finds them
- reuse the helper in the journeys scene instead of a duplicated implementation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a270853c832fa2d9347140b179f4