### PR TITLE
Fix prologue call avatar to show server icon

### DIFF
--- a/src/scenes/PrologueScene.tsx
+++ b/src/scenes/PrologueScene.tsx
@@ -58,13 +58,8 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
     ? SPEAKER_PROFILES.partner.name
     : activeSpeakerProfile.name
 
-  const displayAvatarSrc = isSystemLine
-    ? SERVER_PROFILE.avatar
-    : isSelfLine
-    ? SPEAKER_PROFILES.self.avatars.speaking
-    : isPartnerLine
-    ? SPEAKER_PROFILES.partner.avatars.speaking
-    : activeSpeakerProfile.avatars.idle
+  const displayAvatarSrc = SERVER_PROFILE.avatar
+  const displayAvatarAlt = `${SERVER_PROFILE.name}のアイコン`
 
   useEffect(() => {
     if (currentLine?.variant === 'self' || currentLine?.variant === 'partner') {
@@ -135,7 +130,7 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
             <div className="prologue__call-avatar">
               <img
                 src={displayAvatarSrc}
-                alt={`${displayName}のアイコン`}
+                alt={displayAvatarAlt}
                 onError={handleAvatarError}
                 loading="lazy"
               />


### PR DESCRIPTION
## Summary
- ensure the Prologue call avatar always renders the NESSI server icon with matching alt text

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a3123a6c832fb83a3ee150c41023