### PR TITLE
Fix duplicate asset path imports causing build failure

### DIFF
--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { SceneLayout } from '../components/SceneLayout'
-import { resolveAssetPath } from '../utils/resolveAssetPath'
 import type {
   Journey,
   JourneyCoordinate,
@@ -12,7 +11,7 @@ import type {
 } from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
 import { useHistoryTrackedState } from '../history/useHistoryTrackedState'
-import { resolveAssetPath } from '../utils/assetPaths'
+import { resolveAssetPath } from '../utils/resolveAssetPath'
 
 const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
   year: 'numeric',

--- a/src/utils/assetPaths.ts
+++ b/src/utils/assetPaths.ts
@@ -1,10 +1,1 @@
-export const resolveAssetPath = (path: string): string => {
-  if (!path) return path
-  if (path.startsWith('data:')) return path
-  if (/^(?:https?:)?\/\//.test(path)) return path
-
-  const base = import.meta.env.BASE_URL ?? '/'
-  const sanitizedBase = base.endsWith('/') ? base.slice(0, -1) : base
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`
-  return `${sanitizedBase}${normalizedPath}`
-}
+export { resolveAssetPath } from './resolveAssetPath'


### PR DESCRIPTION
## Summary
- remove the duplicate resolveAssetPath import in JourneysScene so the TypeScript build succeeds again
- reuse the resolveAssetPath helper implementation via re-export to avoid divergence between utils files

## Testing
- npm run build:pages

------
https://chatgpt.com/codex/tasks/task_e_68d9a55e5e4c832fb818ca11984869fc