### PR TITLE
Fix asset paths for static imagery

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2701,22 +2701,22 @@
 
 .prologue__backdrop--self {
   background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
-    url('/images/prologue/Generated Image September 26, 2025 - 2_48AM.png');
+    var(--prologue-self-idle-image);
 }
 
 .prologue__backdrop--self.is-speaking {
   background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
-    url('/images/prologue/Generated Image September 26, 2025 - 2_55AM.png');
+    var(--prologue-self-speaking-image);
 }
 
 .prologue__backdrop--partner {
   background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
-    url('/images/prologue/Generated Image September 26, 2025 - 3_34AM.png');
+    var(--prologue-partner-idle-image);
 }
 
 .prologue__backdrop--partner.is-speaking {
   background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
-    url('/images/prologue/Generated Image September 26, 2025 - 3_37AM.png');
+    var(--prologue-partner-speaking-image);
 }
 
 .prologue__backdrop-overlay {

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { SceneLayout } from '../components/SceneLayout'
-import { resolveAssetPath } from '../utils/resolveAssetPath'
 import type {
   Journey,
   JourneyCoordinate,
@@ -12,7 +11,7 @@ import type {
 } from '../types/journey'
 import type { SceneComponentProps } from '../types/scenes'
 import { useHistoryTrackedState } from '../history/useHistoryTrackedState'
-import { resolveAssetPath } from '../utils/assetPaths'
+import { resolveAssetPath } from '../utils/resolveAssetPath'
 
 const dateFormatter = new Intl.DateTimeFormat('ja-JP', {
   year: 'numeric',

--- a/src/scenes/PrologueScene.tsx
+++ b/src/scenes/PrologueScene.tsx
@@ -1,8 +1,15 @@
-import { useCallback, useEffect, useState } from 'react'
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 
 import { prologueScript } from '../data/prologue'
 import type { SceneComponentProps } from '../types/scenes'
 import { useActionHistory } from '../history/ActionHistoryContext'
+import { resolveAssetPath } from '../utils/resolveAssetPath'
 
 const SPEAKER_PROFILES = {
   self: {
@@ -23,10 +30,21 @@ const SPEAKER_PROFILES = {
 
 const SERVER_PROFILE = {
   name: 'NESSI',
-  avatar: '/images/prologue/IMG_nessi.jpeg',
+  avatar: resolveAssetPath('/images/prologue/IMG_nessi.jpeg'),
 } as const
 
-const FALLBACK_AVATAR_SRC = '/images/prologue-partner-placeholder.svg'
+const FALLBACK_AVATAR_SRC = resolveAssetPath('/images/prologue-partner-placeholder.svg')
+
+const SPEAKER_BACKDROP_IMAGES = {
+  self: {
+    idle: `url(${resolveAssetPath(SPEAKER_PROFILES.self.avatars.idle)})`,
+    speaking: `url(${resolveAssetPath(SPEAKER_PROFILES.self.avatars.speaking)})`,
+  },
+  partner: {
+    idle: `url(${resolveAssetPath(SPEAKER_PROFILES.partner.avatars.idle)})`,
+    speaking: `url(${resolveAssetPath(SPEAKER_PROFILES.partner.avatars.speaking)})`,
+  },
+} as const
 
 const getInitialSpeaker = (): 'self' | 'partner' => {
   const firstSpeaker = prologueScript.find(
@@ -60,6 +78,17 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
 
   const displayAvatarSrc = SERVER_PROFILE.avatar
   const displayAvatarAlt = `${SERVER_PROFILE.name}のアイコン`
+
+  const backdropCustomProperties = useMemo(
+    () =>
+      ({
+        '--prologue-self-idle-image': SPEAKER_BACKDROP_IMAGES.self.idle,
+        '--prologue-self-speaking-image': SPEAKER_BACKDROP_IMAGES.self.speaking,
+        '--prologue-partner-idle-image': SPEAKER_BACKDROP_IMAGES.partner.idle,
+        '--prologue-partner-speaking-image': SPEAKER_BACKDROP_IMAGES.partner.speaking,
+      }) as CSSProperties,
+    []
+  )
 
   useEffect(() => {
     if (currentLine?.variant === 'self' || currentLine?.variant === 'partner') {
@@ -110,6 +139,7 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
       onClick={handleAdvance}
       onKeyDown={handleKeyDown}
       aria-label={isComplete ? 'Journeysへ進む' : 'タップでセリフを進める'}
+      style={backdropCustomProperties}
     >
       <div className="prologue__backdrops" aria-hidden="true">
         <div

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: './',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- ensure the Vite build uses a relative base so GitHub Pages can resolve assets
- resolve Prologue scene imagery through the shared helper and CSS custom properties
- align Journeys scene asset resolution with the helper to avoid missing imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a9c19d9c832f94e1fcc079793f67