### PR TITLE
Reset journey quiz answers between visits

### DIFF
--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -451,6 +451,9 @@ export const JourneysScene = ({
   const responseMap = useMemo(() => {
     const map = new Map<string, typeof responses[number]>()
     responses.forEach((entry) => {
+      if (entry.questionType === 'choice') {
+        return
+      }
       map.set(entry.storageKey, entry)
     })
     return map
@@ -475,10 +478,10 @@ export const JourneysScene = ({
   const handleAnswerChange = useCallback(
     (value: string) => {
       if (!activeQuestion || !activeJourney) return
-      if (activeQuestion.readonlyAfterSave !== false && storedResponse !== undefined) return
-      setDraftAnswer(value, { label: 'Journeys: edit answer' })
+
       if (activeQuestion.style === 'choice') {
-        if (storedResponse?.answer === value) return
+        if (draftAnswer === value) return
+        setDraftAnswer(value, { label: 'Journeys: edit answer' })
         const isCorrect = activeQuestion.correctAnswer
           ? activeQuestion.correctAnswer === value
           : undefined
@@ -495,6 +498,9 @@ export const JourneysScene = ({
         return
       }
 
+      if (activeQuestion.readonlyAfterSave !== false && storedResponse !== undefined) return
+      setDraftAnswer(value, { label: 'Journeys: edit answer' })
+
       if (activeQuestion.readonlyAfterSave === false) {
         if (storedResponse?.answer === value) return
         saveResponse({
@@ -509,7 +515,14 @@ export const JourneysScene = ({
       }
 
     },
-    [activeJourney, activeQuestion, saveResponse, storedResponse]
+    [
+      activeJourney,
+      activeQuestion,
+      draftAnswer,
+      saveResponse,
+      setDraftAnswer,
+      storedResponse,
+    ]
   )
 
   const handleBeginJourneySession = useCallback(() => {


### PR DESCRIPTION
## Summary
- ignore stored multiple-choice journey responses when rendering so quiz cards no longer restore past answers
- adjust the journey quiz answer handler to rely on transient selection state while still updating stored stats

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9ad5adc78832fbefd8087ca29ec33