### PR TITLE
Fix letter viewer controls overlap on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4622,6 +4622,7 @@
   --letter-floating-offset: -36%;
   --letter-floating-scale: 1.14;
   box-shadow: 0 42px 68px rgba(12, 18, 48, 0.28);
+  overflow: visible;
 }
 
 @media (max-width: 640px) {
@@ -4631,8 +4632,9 @@
   }
 
   .letter-pack__letter[data-open='true'] {
-    --letter-floating-offset: clamp(-22%, -28%, -18%);
-    --letter-floating-scale: 1.08;
+    --letter-floating-offset: clamp(-14%, -18%, -10%);
+    --letter-floating-scale: 1.05;
+    overflow: visible;
   }
 }
 
@@ -4640,12 +4642,34 @@
   position: absolute;
   inset: 0;
   display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
   align-items: center;
-  justify-content: space-between;
   pointer-events: none;
   padding: clamp(0.75rem, 3vw, 1.2rem);
+  padding-top: clamp(1.5rem, 6vw, 2.75rem);
   gap: clamp(0.5rem, 2vw, 1rem);
   z-index: 2;
+  background: linear-gradient(
+    180deg,
+    rgba(4, 10, 26, 0) 0%,
+    rgba(4, 10, 26, 0.55) 55%,
+    rgba(4, 10, 26, 0.78) 100%
+  );
+}
+
+.letter-pack__nav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: clamp(0.5rem, 2vw, 1rem);
+  width: 100%;
+  flex-wrap: wrap;
+  pointer-events: none;
+}
+
+.letter-pack__nav-button {
+  pointer-events: auto;
 }
 
 .letter-pack__nav-button {
@@ -4765,6 +4789,33 @@
     padding: clamp(1.1rem, 6vw, 1.9rem);
   }
 
+  .letter-pack__letter-overlay {
+    padding-bottom: clamp(0.9rem, 4vw, 1.2rem);
+  }
+
+  .letter-pack__nav {
+    gap: clamp(0.4rem, 3vw, 0.75rem);
+  }
+
+  .letter-pack__page-status {
+    width: 100%;
+    margin: 0;
+  }
+
+  .letter-pack__nav-button {
+    width: clamp(38px, 11vw, 52px);
+    height: clamp(38px, 11vw, 52px);
+  }
+
+  .letter-pack__nav-button span {
+    transform: translateY(-1px);
+  }
+
+  .letter-pack__letter[data-open='true'] {
+    --letter-floating-offset: clamp(-14%, -18%, -10%);
+    --letter-floating-scale: 1.05;
+    overflow: visible;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/LetterExperience.tsx
+++ b/src/components/LetterExperience.tsx
@@ -1363,11 +1363,16 @@ export const LetterExperience = ({
             {isLetterOpen && (hasPages || onLetterClose) && (
               <div className="letter-pack__letter-overlay">
                 {hasPages && (
-                  <>
+                  <div className="letter-pack__nav" role="group" aria-label="手紙のページ操作">
                     <button
                       type="button"
                       className="letter-pack__nav-button letter-pack__nav-button--prev"
-                      onClick={onLetterPrev}
+                      onPointerDown={(event) => event.stopPropagation()}
+                      onPointerUp={(event) => event.stopPropagation()}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        onLetterPrev?.()
+                      }}
                       disabled={!onLetterPrev}
                       aria-label="前のページへ"
                     >
@@ -1379,19 +1384,30 @@ export const LetterExperience = ({
                     <button
                       type="button"
                       className="letter-pack__nav-button letter-pack__nav-button--next"
-                      onClick={onLetterNext ?? onLetterClick}
+                      onPointerDown={(event) => event.stopPropagation()}
+                      onPointerUp={(event) => event.stopPropagation()}
+                      onClick={(event) => {
+                        event.stopPropagation()
+                        const action = onLetterNext ?? onLetterClick
+                        action?.()
+                      }}
                       disabled={!(onLetterNext ?? onLetterClick)}
                       aria-label="次のページへ"
                     >
                       <span aria-hidden="true">›</span>
                     </button>
-                  </>
+                  </div>
                 )}
                 {onLetterClose && (
                   <button
                     type="button"
                     className="letter-pack__close"
-                    onClick={onLetterClose}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onPointerUp={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onLetterClose()
+                    }}
                     aria-label="封筒に戻す"
                   >
                     <span aria-hidden="true">×</span>


### PR DESCRIPTION
## Summary
- repositioned the letter viewer overlay so the pagination controls sit at the bottom with a soft gradient background
- prevented the navigation buttons from bubbling pointer events into the letter so pages advance one step at a time
- allowed opened letters to extend beyond the pack on small screens to stop the top edge from being clipped

## Testing
- npm run build *(fails: npm command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9adfbcf00832f9271761a390802da