### PR TITLE
Fix prologue backdrops with quoted asset URLs

### DIFF
--- a/src/scenes/PrologueScene.tsx
+++ b/src/scenes/PrologueScene.tsx
@@ -35,14 +35,16 @@ const SERVER_PROFILE = {
 
 const FALLBACK_AVATAR_SRC = resolveAssetPath('/images/prologue-partner-placeholder.svg')
 
+const toCssUrl = (path: string) => `url("${path}")`
+
 const SPEAKER_BACKDROP_IMAGES = {
   self: {
-    idle: `url(${resolveAssetPath(SPEAKER_PROFILES.self.avatars.idle)})`,
-    speaking: `url(${resolveAssetPath(SPEAKER_PROFILES.self.avatars.speaking)})`,
+    idle: toCssUrl(resolveAssetPath(SPEAKER_PROFILES.self.avatars.idle)),
+    speaking: toCssUrl(resolveAssetPath(SPEAKER_PROFILES.self.avatars.speaking)),
   },
   partner: {
-    idle: `url(${resolveAssetPath(SPEAKER_PROFILES.partner.avatars.idle)})`,
-    speaking: `url(${resolveAssetPath(SPEAKER_PROFILES.partner.avatars.speaking)})`,
+    idle: toCssUrl(resolveAssetPath(SPEAKER_PROFILES.partner.avatars.idle)),
+    speaking: toCssUrl(resolveAssetPath(SPEAKER_PROFILES.partner.avatars.speaking)),
   },
 } as const
 


### PR DESCRIPTION
## Summary
- ensure prologue speaker backdrop CSS variables wrap asset URLs in quotes so spaced filenames load correctly
- add helper for generating CSS url strings to avoid missing character backgrounds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c5515610832f8b33c68ae36e3905