### PR TITLE
Adjust ASCII start characters to look more human

### DIFF
--- a/src/components/AsciiStartScene.tsx
+++ b/src/components/AsciiStartScene.tsx
@@ -7,13 +7,13 @@ const CHARACTER_LEFT = {
     ' (•‿•)',
     '  /|\\',
     `  / ${BACKSLASH}${BACKSLASH}`,
-    '+',
+    '  ^ ^',
   ]),
   frameB: createFrame([
     ' (•‿•)',
     '  /|\\',
-    ` ${BACKSLASH}/  ${BACKSLASH}`,
-    '+',
+    ` ${BACKSLASH}/ ${BACKSLASH}`,
+    '  ^ ^',
   ]),
 }
 
@@ -22,13 +22,13 @@ const CHARACTER_RIGHT = {
     ' (•‿•)~',
     '  /|\\',
     `  / ${BACKSLASH}${BACKSLASH}`,
-    '+',
+    '  ^ ^',
   ]),
   frameB: createFrame([
     ' (•‿•)~',
     '  /|\\',
-    ` ${BACKSLASH}/  ${BACKSLASH}`,
-    '+',
+    ` ${BACKSLASH}/ ${BACKSLASH}`,
+    '  ^ ^',
   ]),
 }
 


### PR DESCRIPTION
## Summary
- tweak the ASCII start scene sprites so both animation frames keep a two-leg stance
- add a dedicated feet line to make the characters read as people instead of three-legged figures

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9c87de288832fbc6a8b600d6b00ad