### PR TITLE
Hide maintenance navigation panel unless enabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -214,13 +214,15 @@ function App() {
       {currentSceneId === 'journeys' && (
         <DistanceHUD distanceKm={distanceTraveled} />
       )}
-      <SceneQuickPanel
-        currentSceneId={currentSceneId}
-        goToScene={goToScene}
-        goToNext={goToNextScene}
-        goToPrevious={goToPreviousScene}
-        onRestart={restartExperience}
-      />
+      {allowMaintenanceNavigation && (
+        <SceneQuickPanel
+          currentSceneId={currentSceneId}
+          goToScene={goToScene}
+          goToNext={goToNextScene}
+          goToPrevious={goToPreviousScene}
+          onRestart={restartExperience}
+        />
+      )}
       <main className="scene-container">
         {renderScene(currentSceneId, sceneProps)}
       </main>


### PR DESCRIPTION
## Summary
- hide the scene quick navigation panel unless maintenance navigation is enabled

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da0428b308832fab19c80872ca81ae