### PR TITLE
Lowercase Result player names in Result scene

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -419,10 +419,10 @@
 
 .result-card__title {
   margin: 0;
-  font-size: clamp(1.28rem, 3vw, 1.72rem);
+  font-size: clamp(1.1rem, 2.4vw, 1.42rem);
   font-weight: 700;
   letter-spacing: 0.18em;
-  text-transform: uppercase;
+  text-transform: none;
 }
 
 .result-card__stats {


### PR DESCRIPTION
## Summary
- keep player names in the Result scene cards in their provided casing so they display in lowercase
- reduce the Result card title font size so "reonass0220" no longer crowds the card image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da05626454832f9b95f8319234ec93