### PR TITLE
Adjust prologue backdrop and scene background transitions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,14 +5,24 @@
   min-height: 100lvh;
   min-height: 100dvh;
   position: relative;
-  background: radial-gradient(circle at top, rgba(38, 61, 136, 0.55), transparent 60%),
-    linear-gradient(180deg, #050516 0%, #090320 100%);
+  background: var(
+    --app-shell-background,
+    radial-gradient(circle at top, rgba(38, 61, 136, 0.55), transparent 60%),
+    linear-gradient(180deg, #050516 0%, #090320 100%)
+  );
+  transition: background 420ms ease;
   color: #f5f4ff;
   font-family: 'Inter', 'Noto Sans JP', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   overscroll-behavior: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-shell {
+    transition: none;
+  }
 }
 
 .tap-ripple-field {
@@ -2489,33 +2499,19 @@
 }
 
 .prologue__backdrop--self {
-  background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
-    var(--prologue-self-idle-image);
+  background-image: var(--prologue-self-idle-image);
 }
 
 .prologue__backdrop--self.is-speaking {
-  background-image: linear-gradient(160deg, rgba(46, 64, 160, 0.25), rgba(18, 12, 48, 0.65)),
-    var(--prologue-self-speaking-image);
+  background-image: var(--prologue-self-speaking-image);
 }
 
 .prologue__backdrop--partner {
-  background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
-    var(--prologue-partner-idle-image);
+  background-image: var(--prologue-partner-idle-image);
 }
 
 .prologue__backdrop--partner.is-speaking {
-  background-image: linear-gradient(160deg, rgba(188, 76, 160, 0.35), rgba(32, 18, 68, 0.7)),
-    var(--prologue-partner-speaking-image);
-}
-
-.prologue__backdrop-overlay {
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 20% 20%, rgba(255, 188, 255, 0.18), transparent 45%),
-    radial-gradient(circle at 82% 85%, rgba(82, 140, 255, 0.22), transparent 55%);
-  mix-blend-mode: screen;
-  pointer-events: none;
-  opacity: 0.8;
+  background-image: var(--prologue-partner-speaking-image);
 }
 
 .prologue__content {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState, type CSSProperties } from 'react'
 
 import './App.css'
 import { SceneQuickPanel } from './components/SceneQuickPanel'
@@ -20,6 +20,29 @@ import { PrologueScene } from './scenes/PrologueScene'
 import { ResultScene } from './scenes/ResultScene'
 import type { SceneComponentProps, SceneId } from './types/scenes'
 import { sceneOrder, sceneTitleMap } from './types/scenes'
+
+const sceneBackgrounds: Record<SceneId, string> = {
+  intro:
+    'radial-gradient(circle at top, rgba(38, 61, 136, 0.55), transparent 60%), linear-gradient(180deg, #050516 0%, #090320 100%)',
+  introStart:
+    'radial-gradient(circle at 12% 18%, rgba(118, 162, 255, 0.28), transparent 62%), linear-gradient(180deg, #040720 0%, #080b26 100%)',
+  prologue:
+    'radial-gradient(circle at 16% 12%, rgba(120, 146, 255, 0.18), transparent 58%), radial-gradient(circle at 78% 86%, rgba(255, 169, 214, 0.16), transparent 62%), linear-gradient(180deg, #040514 0%, #070819 100%)',
+  journeys:
+    'radial-gradient(circle at 10% 20%, rgba(64, 196, 255, 0.18), transparent 55%), radial-gradient(circle at 78% 72%, rgba(68, 132, 255, 0.15), transparent 62%), linear-gradient(180deg, #03121f 0%, #041f2f 100%)',
+  messages:
+    'radial-gradient(circle at 16% 18%, rgba(255, 163, 229, 0.18), transparent 60%), radial-gradient(circle at 84% 82%, rgba(124, 174, 255, 0.2), transparent 60%), linear-gradient(180deg, #120725 0%, #1a1038 100%)',
+  likes:
+    'radial-gradient(circle at 14% 16%, rgba(126, 236, 255, 0.2), transparent 60%), radial-gradient(circle at 84% 74%, rgba(90, 206, 255, 0.16), transparent 62%), linear-gradient(180deg, #051422 0%, #08283a 100%)',
+  links:
+    'radial-gradient(circle at 12% 18%, rgba(120, 214, 255, 0.18), transparent 58%), radial-gradient(circle at 82% 78%, rgba(118, 194, 255, 0.16), transparent 60%), linear-gradient(180deg, #04121f 0%, #062034 100%)',
+  media:
+    'radial-gradient(circle at 20% 18%, rgba(188, 162, 255, 0.2), transparent 60%), radial-gradient(circle at 78% 82%, rgba(116, 118, 255, 0.18), transparent 62%), linear-gradient(180deg, #110726 0%, #1b0f36 100%)',
+  letter:
+    'radial-gradient(circle at 12% 16%, rgba(255, 202, 170, 0.2), transparent 58%), radial-gradient(circle at 88% 82%, rgba(255, 173, 149, 0.18), transparent 62%), linear-gradient(180deg, #12070f 0%, #1c0d16 100%)',
+  result:
+    'radial-gradient(circle at 20% 16%, rgba(255, 224, 164, 0.22), transparent 62%), radial-gradient(circle at 78% 84%, rgba(134, 162, 255, 0.18), transparent 64%), linear-gradient(180deg, #090912 0%, #121525 100%)',
+}
 
 const renderScene = (
   sceneId: SceneId,
@@ -208,8 +231,15 @@ function App() {
     reportIntroBootState: setIntroBootState,
   }
 
+  const sceneStyle = useMemo(() => {
+    return {
+      ['--app-shell-background' as const]:
+        sceneBackgrounds[currentSceneId] ?? sceneBackgrounds.intro,
+    } as CSSProperties
+  }, [currentSceneId])
+
   return (
-    <div className={`app-shell scene-${currentSceneId}`}>
+    <div className={`app-shell scene-${currentSceneId}`} style={sceneStyle}>
       {/* HUDはJourneysのみ表示 */}
       {currentSceneId === 'journeys' && (
         <DistanceHUD distanceKm={distanceTraveled} />

--- a/src/scenes/PrologueScene.tsx
+++ b/src/scenes/PrologueScene.tsx
@@ -154,7 +154,6 @@ export const PrologueScene = ({ onAdvance }: SceneComponentProps) => {
             activeBackdrop === 'partner' ? 'is-active' : ''
           } ${isPartnerLine ? 'is-speaking' : ''}`}
         />
-        <div className="prologue__backdrop-overlay" />
       </div>
       <div className="prologue__content">
         <header className="prologue__call-ui" aria-live="polite">


### PR DESCRIPTION
## Summary
- remove the pink-tinted overlays from the Prologue backdrops so the original illustrations remain visible
- drive the app-shell background from the active scene and define gradients that better match each scene's mood

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daaa734b5c832fa1c118fe159d2e95