### PR TITLE
Preload prologue backdrops during intro

### DIFF
--- a/src/data/preloadManifest.ts
+++ b/src/data/preloadManifest.ts
@@ -47,6 +47,17 @@ resultLegends.forEach((legend) => {
   }
 })
 
+const prologueBackdropImages = new Set([
+  '/images/prologue/Generated Image September 26, 2025 - 2_48AM.png',
+  '/images/prologue/Generated Image September 26, 2025 - 2_55AM.png',
+  '/images/prologue/Generated Image September 26, 2025 - 3_34AM.png',
+  '/images/prologue/Generated Image September 26, 2025 - 3_37AM.png',
+])
+
+prologueBackdropImages.forEach((src) => {
+  localImageSet.add(src)
+})
+
 const remoteMeetupImages = new Set<string>()
 
 meetupPages.forEach((page) => {


### PR DESCRIPTION
## Summary
- add the four prologue backdrop portraits to the intro preloader so they are ready before the scene starts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68daacd26304832fbb32b4060f531c3a