### PR TITLE
Update start screen titles

### DIFF
--- a/src/scenes/IntroStartScene.tsx
+++ b/src/scenes/IntroStartScene.tsx
@@ -55,8 +55,8 @@ export const IntroStartScene = ({
       <GlobalStarfield />
       <AsciiStartScene />
       <div className="start-ui">
-        <h1 className="start-title">First Anniversary ~libft &amp; reonass0220~</h1>
-        <p className="start-subtitle">First Anniversary ~libft &amp; reonass0220~</p>
+        <h1 className="start-title">First Anniversary</h1>
+        <p className="start-subtitle">~libft &amp; reonass0220~</p>
         <div className="start-tap">
           <span className="tap-dot" /> TAP ANYWHERE TO START
         </div>


### PR DESCRIPTION
## Summary
- Start画面のタイトルを「First Anniversary」に更新
- サブタイトルを「~libft & reonass0220~」に変更

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab092ca6c832f88a92df7dbd6bcc1