### PR TITLE
Remove Journeys header label and build stamp

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { useCallback, useMemo, useState, type CSSProperties } from 'react'
 import './App.css'
 import { SceneQuickPanel } from './components/SceneQuickPanel'
 import { DistanceHUD } from './components/DistanceHUD'
-import { BuildStamp } from './components/BuildStamp'
 import { GlobalBackButton } from './components/GlobalBackButton'
 import { journeys } from './data/journeys'
 import { useStoredJourneyResponses } from './hooks/useStoredJourneyResponses'
@@ -256,7 +255,6 @@ function App() {
       <main className="scene-container">
         {renderScene(currentSceneId, sceneProps)}
       </main>
-      <BuildStamp />
       <footer className="scene-footer" aria-hidden="true">
         <span className="scene-footer__label">SCENE</span>
         <span className="scene-footer__value">{sceneTitleMap[currentSceneId]}</span>

--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -695,7 +695,7 @@ export const JourneysScene = ({
   })()
 
   return (
-    <SceneLayout eyebrow="Journeys">
+    <SceneLayout>
       <div
         ref={stageRef}
         className="journeys-stage"


### PR DESCRIPTION
## Summary
- JourneysシーンのヘッダーからJOURNEYSラベルを外しました
- グローバルに表示されていたビルドスタンプを削除しました

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab2438a98832f9b3054951401454c