### PR TITLE
Fix incorrect correct-answer string for Kyoto temple quiz

### DIFF
--- a/src/data/journeys.ts
+++ b/src/data/journeys.ts
@@ -659,7 +659,7 @@ const newJourneyDefinitions: JourneyInput[] = [
           '3,伏見稲荷',
           '4,平安神宮',
         ],
-        correctAnswer: '２の龍安寺',
+        correctAnswer: '2,龍安寺',
         readonlyAfterSave: true,
       },
       {


### PR DESCRIPTION
## Summary
- fix the Kyoto temple quiz data so the stored answer matches the correct choice and is evaluated properly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab492154c832f855d350612b6a48f