### PR TITLE
Lock quiz answers after first selection

### DIFF
--- a/src/scenes/JourneysScene.tsx
+++ b/src/scenes/JourneysScene.tsx
@@ -501,9 +501,6 @@ export const JourneysScene = ({
   const responseMap = useMemo(() => {
     const map = new Map<string, typeof responses[number]>()
     responses.forEach((entry) => {
-      if (entry.questionType === 'choice') {
-        return
-      }
       map.set(entry.storageKey, entry)
     })
     return map
@@ -530,6 +527,9 @@ export const JourneysScene = ({
       if (!activeQuestion || !activeJourney) return
 
       if (activeQuestion.style === 'choice') {
+        if (storedResponse) {
+          return
+        }
         if (draftAnswer === value) return
         setDraftAnswer(value, { label: 'Journeys: edit answer' })
         const isCorrect = activeQuestion.correctAnswer


### PR DESCRIPTION
## Summary
- store choice question responses in the journey response map so saved answers lock quiz options
- guard quiz answer updates when a stored response already exists to prevent changes after the first selection

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dabab14ff4832f9fd09490353e297c