### PR TITLE
Fix result card image layout on small screens

### DIFF
--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -305,16 +305,14 @@
 
 @media (max-width: 820px) {
   .result-card {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      'body'
-      'image';
+    grid-template-columns: minmax(0, 1fr) minmax(140px, 48%, 200px);
+    grid-template-areas: 'body image';
+    align-items: stretch;
     gap: clamp(16px, 5vw, 24px);
   }
 
   .result-card__image {
-    min-height: clamp(210px, 58vw, 280px);
-    justify-self: stretch;
+    min-height: auto;
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the result player card image locked to the right column even on narrow screens
- remove the vertical stacking fallback that caused the placeholder to overlap the stats area

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dabf2f81cc832f80bcd9a9db057287