### PR TITLE
Fix Result scene mobile layout and enable scrolling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -155,6 +155,7 @@
   min-height: 0;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
 }
 
 .scene-footer {

--- a/src/scenes/ResultScene.css
+++ b/src/scenes/ResultScene.css
@@ -316,6 +316,25 @@
   }
 }
 
+@media (max-width: 720px) {
+  .result-card {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      'body'
+      'image';
+    aspect-ratio: auto;
+    height: auto;
+  }
+
+  .result-card__body {
+    height: auto;
+  }
+
+  .result-card__image {
+    min-height: clamp(200px, 62vw, 260px);
+  }
+}
+
 .result-header__divider {
   width: calc(100% - clamp(40px, 6vw, 72px));
   height: 1px;


### PR DESCRIPTION
## Summary
- allow vertical touch scrolling within the scene container so the Result view can scroll on touch devices
- adjust Result cards to stack on narrow screens and remove the fixed aspect ratio to prevent text from overlapping the player image

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacc4a03f0832f926e1889dc0abe43