### PR TITLE
Fix Journeys distance HUD overlapping issue

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -806,6 +806,8 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  z-index: 20;
+  white-space: nowrap;
 }
 
 .distance-hud__label {


### PR DESCRIPTION
## Summary
- raise the Journeys distance HUD above surrounding content so the total distance is no longer occluded
- prevent the HUD text from wrapping to keep the distance display intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db5f3ed040832fa4117a81649904f4